### PR TITLE
Search icon squeezed

### DIFF
--- a/android/app/src/main/java/org/jetbrains/kotlinconf/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/jetbrains/kotlinconf/ui/MainActivity.kt
@@ -50,6 +50,15 @@ class MainActivity : AppCompatActivity(), AnkoComponent<Context>, NavigationMana
             searchView.isIconified = false
         }
 
+        searchView.setOnSearchClickListener {
+            supportActionBar?.setLogo(R.drawable.kotlinconf_logo)
+        }
+
+        searchView.setOnCloseListener {
+            supportActionBar?.setLogo(R.drawable.kotlinconf_logo_text)
+            return@setOnCloseListener false
+        }
+
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean = false
             override fun onQueryTextChange(newText: String): Boolean {


### PR DESCRIPTION
Use icon without the text when the search is expanded


| Before | After |
| :---: |:---:|
| ![screenshot_1537137248](https://user-images.githubusercontent.com/2514790/45601762-16d07680-ba0a-11e8-9751-76f369991068.png) | ![screenshot_1537137225](https://user-images.githubusercontent.com/2514790/45601761-16d07680-ba0a-11e8-8850-2bfc9caee829.png) |
