### PR TITLE
Require terms acceptance to use app at all

### DIFF
--- a/android/app/src/main/java/org/jetbrains/kotlinconf/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/jetbrains/kotlinconf/ui/MainActivity.kt
@@ -104,7 +104,7 @@ class MainActivity : AppCompatActivity(), AnkoComponent<Context>, NavigationMana
     }
 
     override fun showVotingCodePromptDialog() {
-        CodeEnterFragment().show(supportFragmentManager, CodeEnterFragment.TAG)
+        CodeEnterFragment.show(supportFragmentManager)
     }
 
     override fun showSessionDetails(sessionId: String) {
@@ -121,6 +121,8 @@ class MainActivity : AppCompatActivity(), AnkoComponent<Context>, NavigationMana
             .replace(R.id.fragment_container, fragment, SessionDetailsFragment.TAG)
             .commit()
     }
+
+    private fun isVotingCodePromptNotVisible() = fragmentManager.findFragmentByTag(CodeEnterFragment.TAG) == null
 
     companion object {
         private const val SEARCH_QUERY_KEY = "SearchQuery"

--- a/android/app/src/main/java/org/jetbrains/kotlinconf/ui/SessionDetailsFragment.kt
+++ b/android/app/src/main/java/org/jetbrains/kotlinconf/ui/SessionDetailsFragment.kt
@@ -54,7 +54,7 @@ class SessionDetailsFragment : BaseFragment(), SessionDetailsView {
         okButton.setOnClickListener { presenter.rateSessionClicked(OK) }
         badButton.setOnClickListener { presenter.rateSessionClicked(BAD) }
         verifyCodeButton.setOnClickListener {
-            CodeEnterFragment().show(fragmentManager, CodeEnterFragment.TAG)
+            CodeEnterFragment.show(fragmentManager ?: return@setOnClickListener)
         }
         presenter.onCreate()
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -190,4 +190,5 @@ liability.</p> ]]></string>
     <string name="code_incorrect">Sorry, the code entered is incorrect</string>
     <string name="voting_text">In order to enable voting, please enter your voting code</string>
     <string name="verify_button_text">Verify voting code</string>
+    <string name="msg_need_to_accept_terms">To use application, you need to accept the terms and conditions</string>
 </resources>

--- a/common/src/main/kotlin/org/jetbrains/kotlinconf/model/KotlinConfDataRepository.kt
+++ b/common/src/main/kotlin/org/jetbrains/kotlinconf/model/KotlinConfDataRepository.kt
@@ -21,10 +21,10 @@ class KotlinConfDataRepository(
     override var votes: List<Vote>? by bindToPreferencesByKey("votesKey", Vote.serializer().list)
     private var userId: String? by bindToPreferencesByKey("userIdKey", String.serializer())
 
-    override var codePromptShown: Boolean
-        get() = settings.getBoolean("codePromptShownKey", false)
+    override var termsAccepted: Boolean
+        get() = settings.getBoolean("termsAcceptedKey", false)
         set(value) {
-            settings.putBoolean("codePromptShownKey", value)
+            settings.putBoolean("termsAcceptedKey", value)
         }
 
     override val loggedIn: Boolean
@@ -50,11 +50,10 @@ class KotlinConfDataRepository(
         }
     }
 
-    override suspend fun verifyCode(code: VotingCode) {
+    override suspend fun verifyAndSetCode(code: VotingCode) {
         try {
             api.verifyCode(code)
             userId = code
-            update()
         } catch (t: Throwable) {
             val responseStatus = (t.cause as? ApiException)?.response?.status?.value
             if (responseStatus == 406) {

--- a/common/src/main/kotlin/org/jetbrains/kotlinconf/presentation/CodeVerificationPresenter.kt
+++ b/common/src/main/kotlin/org/jetbrains/kotlinconf/presentation/CodeVerificationPresenter.kt
@@ -8,13 +8,40 @@ class CodeVerificationPresenter(
     private val view: CodeVerificationView,
     private val repository: DataRepository
 ) {
-    fun verifyCode(code: String) {
+    fun onCreate() {
+        view.termsAccepted = repository.termsAccepted
+    }
+
+    fun onSubmit(code: String) {
+        checkTermsAcceptedAnd {
+            verifyCode(code)
+        }
+    }
+
+    fun onCancel() {
+        checkTermsAcceptedAnd {
+            view.dismissView()
+        }
+    }
+
+    private fun verifyCode(code: String) {
         launchAndCatch(uiContext, view::showError) {
             view.setProgress(true)
-            repository.verifyCode(code)
+            repository.verifyAndSetCode(code)
+            repository.update()
             view.dismissView()
         } finally {
             view.setProgress(false)
+        }
+    }
+
+    private inline fun checkTermsAcceptedAnd(f: ()->Unit) {
+        val termsAccepted = view.termsAccepted
+        repository.termsAccepted = termsAccepted
+        if(termsAccepted) {
+            f()
+        } else {
+            view.showTermsAcceptanceRequired()
         }
     }
 }

--- a/common/src/main/kotlin/org/jetbrains/kotlinconf/presentation/CodeVerificationView.kt
+++ b/common/src/main/kotlin/org/jetbrains/kotlinconf/presentation/CodeVerificationView.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.kotlinconf.presentation
 
 interface CodeVerificationView : BaseView {
+    var termsAccepted: Boolean
     fun setProgress(isLoading: Boolean)
     fun dismissView()
+    fun showTermsAcceptanceRequired()
 }

--- a/common/src/main/kotlin/org/jetbrains/kotlinconf/presentation/DataRepository.kt
+++ b/common/src/main/kotlin/org/jetbrains/kotlinconf/presentation/DataRepository.kt
@@ -9,12 +9,12 @@ interface DataRepository {
     val votes: List<Vote>?
     var onRefreshListeners: List<() -> Unit>
     val loggedIn: Boolean
-    var codePromptShown: Boolean
+    var termsAccepted: Boolean
 
     suspend fun update()
     fun getRating(sessionId: String): SessionRating?
     suspend fun addRating(sessionId: String, rating: SessionRating)
     suspend fun removeRating(sessionId: String)
     suspend fun setFavorite(sessionId: String, isFavorite: Boolean)
-    suspend fun verifyCode(code: VotingCode)
+    suspend fun verifyAndSetCode(code: VotingCode)
 }

--- a/common/src/main/kotlin/org/jetbrains/kotlinconf/presentation/SessionListPresenter.kt
+++ b/common/src/main/kotlin/org/jetbrains/kotlinconf/presentation/SessionListPresenter.kt
@@ -21,9 +21,8 @@ class SessionListPresenter(
         showData()
         updateData()
 
-        if (!repository.loggedIn && !repository.codePromptShown) {
+        if (!repository.termsAccepted) {
             navigationManager.showVotingCodePromptDialog()
-            repository.codePromptShown = true
         }
     }
 


### PR DESCRIPTION
New logic: Now terms and conditions must be accepted to allow application usage at all. So when we open application and they are not accepted, the prompt is shown. A user cannot cancel it without accepting terms and conditions. 