### PR TITLE
Fix logo in the menu

### DIFF
--- a/android/app/src/main/java/org/jetbrains/kotlinconf/ui/InfoFragment.kt
+++ b/android/app/src/main/java/org/jetbrains/kotlinconf/ui/InfoFragment.kt
@@ -36,6 +36,7 @@ class InfoFragment : Fragment(), AnkoComponent<Context> {
             supportActionBar?.setDisplayShowHomeEnabled(true)
             supportActionBar?.setDisplayShowTitleEnabled(false)
             supportActionBar?.setDisplayHomeAsUpEnabled(true)
+            supportActionBar?.setDisplayUseLogoEnabled(false)
         }
     }
 

--- a/android/app/src/main/java/org/jetbrains/kotlinconf/ui/MainActivity.kt
+++ b/android/app/src/main/java/org/jetbrains/kotlinconf/ui/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : AppCompatActivity(), AnkoComponent<Context>, NavigationMana
         val searchViewMenuItem = menu.findItem(R.id.search)
         val searchView = searchViewMenuItem.actionView as SearchView
         if (searchQuery.isNotEmpty()) {
+            supportActionBar?.setLogo(R.drawable.kotlinconf_logo)
             searchView.setQuery(searchQuery, false)
             searchView.isIconified = false
         }

--- a/android/app/src/main/java/org/jetbrains/kotlinconf/ui/SessionDetailsFragment.kt
+++ b/android/app/src/main/java/org/jetbrains/kotlinconf/ui/SessionDetailsFragment.kt
@@ -135,6 +135,7 @@ class SessionDetailsFragment : BaseFragment(), SessionDetailsView {
             supportActionBar?.setDisplayShowHomeEnabled(true)
             supportActionBar?.setDisplayShowTitleEnabled(false)
             supportActionBar?.setDisplayHomeAsUpEnabled(true)
+            supportActionBar?.setDisplayUseLogoEnabled(false)
         }
     }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -195,5 +195,5 @@ liability.</p> ]]></string>
     <string name="code_verification_failed">Failed to verify the code</string>
     <string name="code_incorrect">Sorry, the code entered is incorrect</string>
     <string name="rating_text">In order to enable rating, please enter your code</string>
-    <string name="verify_button_text">Verify rating code</string>
+    <string name="verify_button_text">Verify code</string>
 </resources>


### PR DESCRIPTION
#### Steps to reproduce
1. Filter sessions by typing to the search view on the main screen (`MainActivity` and `SessionDetailsFragment`)
2. Go to the session details
3. Press back (arrow or keyboard)
4. The displayed logo contains text and it's squashed

#### Fix
Set the logo to the icon-only one when the text in a search query is present. Disable logo visibility on `InfoFragment.kt` and `SessionDetailsFragment.kt`.

| Before | After |
| :---: | :---: |
| ![before](https://user-images.githubusercontent.com/2514790/45853942-3801d180-bd40-11e8-9286-ec7888417938.gif) | ![after](https://user-images.githubusercontent.com/2514790/45853941-3801d180-bd40-11e8-8d82-33af337cd7eb.gif) |

#### Other business
- PR also addresses a comment of @hhariri (https://github.com/JetBrains/kotlinconf-app/pull/32#discussion_r219029046) which I missed before merging https://github.com/JetBrains/kotlinconf-app/pull/32. I know I supposed to open a new PR for this, but considering the size of the change (https://github.com/JetBrains/kotlinconf-app/commit/a7decf0e46f8d9bd1d97b89f3022a44e0f9e86f8) I decided to include it here, even though is not related to the logo fix at all.