### PR TITLE
build: configure buildscript in root build file only

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    dependencies {
-        classpath "com.android.tools.build:gradle:$gradle_android_version"
-    }
-    repositories {
-        google()
-    }
-}
-
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        maven { url "http://kotlin.bintray.com/kotlin-dev" }
-        jcenter()
-        google()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:$gradle_android_version"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
 allprojects {
     repositories {
         google()

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-        mavenCentral()
-        mavenLocal()
-    }
-    dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
-    }
-}
-
 apply plugin: 'kotlin'
 apply plugin: 'kotlinx-serialization'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,22 @@
-allprojects {
-    buildscript {
-        repositories {
-            maven { url "http://kotlin.bintray.com/kotlin-eap" }
-            maven { url "http://kotlin.bintray.com/kotlin-dev" }
-            maven { url "https://kotlin.bintray.com/kotlinx" }
-            maven { url 'https://dl.bintray.com/jetbrains/kotlin-native-dependencies' }
+buildscript {
+    repositories {
+        maven { url "http://kotlin.bintray.com/kotlin-eap" }
+        maven { url "http://kotlin.bintray.com/kotlin-dev" }
+        maven { url "https://kotlin.bintray.com/kotlinx" }
+        maven { url 'https://dl.bintray.com/jetbrains/kotlin-native-dependencies' }
 
-            google()
-            jcenter()
-        }
-        dependencies {
-            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-            classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-        }
+        google()
+        jcenter()
     }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
+        classpath "com.android.tools.build:gradle:$gradle_android_version"
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
+    }
+}
+
+allprojects {
     repositories {
         maven { url "http://kotlin.bintray.com/kotlin-eap" }
         maven { url "http://kotlin.bintray.com/kotlin-dev" }


### PR DESCRIPTION
The `buildscript {}` block should be used in the root build file only (see [this recent advice](https://discuss.gradle.org/t/multiproject-gradle-seems-to-need-plugin-repository-declared-in-each-subproject/27970/4) from Gradle core dev).

This PR removes all applications of `buildscript {}` from subprojects as recommended.