### PR TITLE
Set up Wasm proxy for Sessionize images

### DIFF
--- a/shared/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/main.wasm.kt
+++ b/shared/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/main.wasm.kt
@@ -2,9 +2,11 @@ package org.jetbrains.kotlinconf
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.CanvasBasedWindow
+import org.jetbrains.kotlinconf.ui.initCoil
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+    initCoil()
     CanvasBasedWindow {
         App(ApplicationContext())
     }

--- a/ui-components-gallery/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/main.wasm.kt
+++ b/ui-components-gallery/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/main.wasm.kt
@@ -3,9 +3,11 @@ package org.jetbrains.kotlinconf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.CanvasBasedWindow
 import org.jetbrains.kotlinconf.ui.components.GalleryApp
+import org.jetbrains.kotlinconf.ui.initCoil
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+    initCoil()
     CanvasBasedWindow {
         GalleryApp()
     }

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Speaker.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Speaker.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import kotlinconfapp.ui_components.generated.resources.Res
+import kotlinconfapp.ui_components.generated.resources.kodee_emotion_negative
+import kotlinconfapp.ui_components.generated.resources.kodee_emotion_neutral
 import kotlinconfapp.ui_components.generated.resources.kodee_emotion_positive
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -43,7 +45,7 @@ fun Speaker(
                 .background(KotlinConfTheme.colors.tileBackground),
             contentScale = ContentScale.Crop,
             placeholder = painterResource(Res.drawable.kodee_emotion_positive),
-            error = painterResource(Res.drawable.kodee_emotion_positive),
+            error = painterResource(Res.drawable.kodee_emotion_neutral),
         )
         Column {
             StyledText(
@@ -68,12 +70,12 @@ internal fun SpeakerPreview() {
         Speaker(
             name = "John Doe",
             title = "Whatever Role Name at That Company",
-            photoUrl = "bad bad url",
+            photoUrl = "https://example.com/not-an-image.jpg",
         )
         Speaker(
             name = "John Doe",
             title = "Whatever Role Name at That Company",
-            photoUrl = "https://kotlinconf.com/static/sebastian-aigner-ffc95c92c3b7ade7d25a738c40015a68.png",
+            photoUrl = "https://sessionize.com/image/2e2f-0o0o0-XGxKBoqZvxxQxosrZHQHTT.png?download=sebastian-aigner.png",
         )
     }
 }

--- a/ui-components/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/ui/InitCoil.kt
+++ b/ui-components/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/ui/InitCoil.kt
@@ -18,6 +18,7 @@ fun initCoil() {
     }
 }
 
+private val sessionizeBaseUrl = "https://sessionize.com/"
 private val sessionizeProxy = "https://sessionize-com.labs.jb.gg/"
 
 private class SessionizeImageInterceptor : Interceptor {
@@ -25,8 +26,8 @@ private class SessionizeImageInterceptor : Interceptor {
         val originalRequest = chain.request
         val data = originalRequest.data
 
-        val newChain = if (data is String && data.startsWith("https://sessionize.com/")) {
-            val newUri = data.replace("https://sessionize.com/", sessionizeProxy)
+        val newChain = if (data is String && data.startsWith(sessionizeBaseUrl)) {
+            val newUri = data.replace(sessionizeBaseUrl, sessionizeProxy)
             val newRequest = originalRequest.newBuilder().data(newUri).build()
             chain.withRequest(newRequest)
         } else {

--- a/ui-components/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/ui/InitCoil.kt
+++ b/ui-components/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/ui/InitCoil.kt
@@ -1,0 +1,38 @@
+package org.jetbrains.kotlinconf.ui
+
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.intercept.Interceptor
+import coil3.request.ImageResult
+import coil3.util.DebugLogger
+
+fun initCoil() {
+    SingletonImageLoader.setSafe {
+        ImageLoader.Builder(PlatformContext.INSTANCE)
+            .components {
+                add(SessionizeImageInterceptor())
+            }
+            .logger(DebugLogger())
+            .build()
+    }
+}
+
+private val sessionizeProxy = "https://sessionize-com.labs.jb.gg/"
+
+private class SessionizeImageInterceptor : Interceptor {
+    override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
+        val originalRequest = chain.request
+        val data = originalRequest.data
+
+        val newChain = if (data is String && data.startsWith("https://sessionize.com/")) {
+            val newUri = data.replace("https://sessionize.com/", sessionizeProxy)
+            val newRequest = originalRequest.newBuilder().data(newUri).build()
+            chain.withRequest(newRequest)
+        } else {
+            chain
+        }
+
+        return newChain.proceed()
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/JetBrains/kotlinconf-app/issues/202, sets up a new version of the Sessionize image proxy that was initially removed in https://github.com/JetBrains/kotlinconf-app/pull/198