### PR TITLE
Create Schedule screen (part 2)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ androidx-test-junit = "1.2.1"
 androidx-work-runtime = "2.9.1"
 androidx-preference = "1.2.1"
 
-kotlin = "2.1.20-Beta2"
+kotlin = "2.1.10-firework.33"
 
 compose-android = "1.7.6"
 compose-multiplatform = "1.8.0-alpha02"

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
@@ -63,8 +63,8 @@ private fun koinConfiguration(context: ApplicationContext) = koinConfiguration {
         single { APIClient(URLs.API_ENDPOINT) }
         single<ApplicationStorage> { MultiplatformSettingsStorage(context) }
         single { NotificationManager(context) }
-//        single<TimeProvider> { ServerBasedTimeProvider(get()) }
-        single<TimeProvider> { FakeTimeProvider() }
+        single<TimeProvider> { ServerBasedTimeProvider(get()) }
+//        single<TimeProvider> { FakeTimeProvider() }
         singleOf(::ConferenceService)
     }
 

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
@@ -16,9 +16,11 @@ import org.jetbrains.kotlinconf.navigation.KotlinConfNavHost
 import org.jetbrains.kotlinconf.screens.ScheduleViewModel
 import org.jetbrains.kotlinconf.screens.SessionViewModel
 import org.jetbrains.kotlinconf.screens.SettingsViewModel
+import org.jetbrains.kotlinconf.storage.MultiplatformSettingsStorage
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
 import org.koin.compose.KoinMultiplatformApplication
 import org.koin.compose.koinInject
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.koinConfiguration
 import org.koin.dsl.module
@@ -57,13 +59,11 @@ fun App(context: ApplicationContext) {
 
 private fun koinConfiguration(context: ApplicationContext) = koinConfiguration {
     val appModule = module {
-        single<ApplicationContext> { context }
-        single<ConferenceService> {
-            ConferenceService(
-                get<ApplicationContext>(),
-                URLs.API_ENDPOINT
-            )
-        }
+        single { APIClient(URLs.API_ENDPOINT) }
+        single { MultiplatformSettingsStorage(context) }
+        single { NotificationManager(context) }
+        singleOf(::TimeProvider)
+        singleOf(::ConferenceService)
     }
 
     val viewModelModule = module {

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlinconf.navigation.KotlinConfNavHost
 import org.jetbrains.kotlinconf.screens.ScheduleViewModel
 import org.jetbrains.kotlinconf.screens.SessionViewModel
 import org.jetbrains.kotlinconf.screens.SettingsViewModel
+import org.jetbrains.kotlinconf.storage.ApplicationStorage
 import org.jetbrains.kotlinconf.storage.MultiplatformSettingsStorage
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
 import org.koin.compose.KoinMultiplatformApplication
@@ -60,9 +61,10 @@ fun App(context: ApplicationContext) {
 private fun koinConfiguration(context: ApplicationContext) = koinConfiguration {
     val appModule = module {
         single { APIClient(URLs.API_ENDPOINT) }
-        single { MultiplatformSettingsStorage(context) }
+        single<ApplicationStorage> { MultiplatformSettingsStorage(context) }
         single { NotificationManager(context) }
-        singleOf(::TimeProvider)
+//        single<TimeProvider> { ServerBasedTimeProvider(get()) }
+        single<TimeProvider> { FakeTimeProvider() }
         singleOf(::ConferenceService)
     }
 

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/ConferenceService.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/ConferenceService.kt
@@ -22,6 +22,7 @@ val UNKNOWN_SESSION_CARD: SessionCardView = SessionCardView(
     locationLine = "unknown",
     startsAt = GMTDate.START,
     endsAt = GMTDate.START,
+    isLive = false,
     speakerIds = emptyList(),
     isFinished = false,
     isFavorite = false,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
@@ -10,6 +10,7 @@ data class SessionCardView(
     val locationLine: String,
     val startsAt: GMTDate,
     val endsAt: GMTDate,
+    val isLive: Boolean,
     val speakerIds: List<SpeakerId>,
     val vote: Score?,
     val timeLine: String = buildString {

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/TimeProvider.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/TimeProvider.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.kotlinconf
+
+import io.ktor.util.date.GMTDate
+import io.ktor.util.date.plus
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class TimeProvider(private val client: APIClient) {
+    private var serverTime = GMTDate()
+    private var requestTime = GMTDate()
+
+    fun now(): GMTDate = GMTDate() + (serverTime.timestamp - requestTime.timestamp)
+
+    private val _time = MutableStateFlow(GMTDate())
+    val time: StateFlow<GMTDate> = _time.asStateFlow()
+
+    suspend fun run(): Nothing {
+        runCatching {
+            serverTime = client.getServerTime()
+            requestTime = GMTDate()
+        }
+        _time.value = now()
+
+        while (true) {
+            delay(60_000)
+            _time.value = now()
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/TimeProvider.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/TimeProvider.kt
@@ -1,22 +1,29 @@
 package org.jetbrains.kotlinconf
 
 import io.ktor.util.date.GMTDate
+import io.ktor.util.date.Month
 import io.ktor.util.date.plus
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class TimeProvider(private val client: APIClient) {
+interface TimeProvider {
+    fun now(): GMTDate
+    val time: StateFlow<GMTDate>
+    suspend fun run(): Nothing
+}
+
+class ServerBasedTimeProvider(private val client: APIClient) : TimeProvider {
     private var serverTime = GMTDate()
     private var requestTime = GMTDate()
 
-    fun now(): GMTDate = GMTDate() + (serverTime.timestamp - requestTime.timestamp)
+    override fun now(): GMTDate = GMTDate() + (serverTime.timestamp - requestTime.timestamp)
 
     private val _time = MutableStateFlow(GMTDate())
-    val time: StateFlow<GMTDate> = _time.asStateFlow()
+    override val time: StateFlow<GMTDate> = _time.asStateFlow()
 
-    suspend fun run(): Nothing {
+    override suspend fun run(): Nothing {
         runCatching {
             serverTime = client.getServerTime()
             requestTime = GMTDate()
@@ -27,5 +34,17 @@ class TimeProvider(private val client: APIClient) {
             delay(60_000)
             _time.value = now()
         }
+    }
+}
+
+class FakeTimeProvider(
+    private val fixedTime: GMTDate = GMTDate(
+        year = 2024, month = Month.MAY, dayOfMonth = 23, hours = 13, minutes = 40, seconds = 0
+    )
+) : TimeProvider {
+    override val time: StateFlow<GMTDate> = MutableStateFlow(fixedTime)
+    override fun now(): GMTDate = fixedTime
+    override suspend fun run(): Nothing {
+        do while (true)
     }
 }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
@@ -57,8 +57,6 @@ data class TimeSlot(
 
     val key: String =
         "${startsAt.timestamp}-${endsAt.timestamp}-$title-$isBreak-$isParty-$isLunch-${startsAt.dayOfMonth}"
-
-    val duration: String = "${(endsAt.timestamp - startsAt.timestamp) / 1000 / 60} MIN"
 }
 
 fun Conference.buildAgenda(
@@ -68,11 +66,15 @@ fun Conference.buildAgenda(
 ): Agenda {
     val days = sessions
         .groupBy { it.startsAt.dayOfMonth }
-        .toList()
         .map { (day, sessions) ->
             Day(
-                EventDay.from(day),
-                sessions.groupByTime(conference = this, now, favorites, votes)
+                day = EventDay.from(day),
+                timeSlots = sessions.groupByTime(
+                    conference = this,
+                    now = now,
+                    favorites = favorites,
+                    votes = votes,
+                )
             )
         }
         .sortedBy { it.day }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
@@ -125,6 +125,7 @@ fun Session.asSessionCard(
         isFavorite = id in favorites,
         startsAt = startsAt,
         endsAt = endsAt,
+        isLive = startsAt <= now && now < endsAt,
         speakerIds = speakerIds,
         isFinished = isFinished,
         vote = vote,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
@@ -37,6 +37,9 @@ data class SessionItem(
     val speakerHighlights: List<IntRange> = emptyList(),
 ) : ScheduleListItem
 
+fun ScheduleListItem.isLive(): Boolean =
+    (this is SessionItem && this.value.isLive) || (this is TimeSlotTitleItem && this.value.isLive)
+
 // TODO get set of tags from the service
 private val categoryTags = listOf(
     "Server-side",


### PR DESCRIPTION
Adds the Now button to the header of the screen. Time for the service is now provided by a `TimeProvider`, which has a fake implementation that can put our current time in the middle of the test data from 2024 that we're currently working with.

https://github.com/user-attachments/assets/30e14e31-f26b-4b3e-ae02-42eef67eec20



TODOs remaining on this screen:

- Displaying when a session is coming up soon
- Highlighting workshops in a separate scroller at the top
- Service events
- Filtering tags being based on real data instead of hardcoded values
- Improvements on date and string handling (currently too hardcoded)
- State preservation around navigation

