### PR TITLE
Create Schedule screen (part 3)

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -106,6 +106,10 @@ We will process your data in accordance with the App Privacy Policy. You can adj
 
     <string name="schedule_action_filter_bookmarked">Filter bookmarked</string>
     <string name="schedule_action_search">Search</string>
+    <plurals name="schedule_in_x_minutes">
+        <item quantity="one">In %1$d minute</item>
+        <item quantity="other">In %1$d minutes</item>
+    </plurals>
 
     <string name="session_title">Schedule</string>
     <string name="session_how_was_the_talk">How was the talk?</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -106,10 +106,7 @@ We will process your data in accordance with the App Privacy Policy. You can adj
 
     <string name="schedule_action_filter_bookmarked">Filter bookmarked</string>
     <string name="schedule_action_search">Search</string>
-    <plurals name="schedule_in_x_minutes">
-        <item quantity="one">In %1$d minute</item>
-        <item quantity="other">In %1$d minutes</item>
-    </plurals>
+    <string name="schedule_in_x_minutes">in %1$d min</string>
 
     <string name="session_title">Schedule</string>
     <string name="session_how_was_the_talk">How was the talk?</string>

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/ConferenceService.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/ConferenceService.kt
@@ -24,15 +24,13 @@ val UNKNOWN_SESSION_CARD: SessionCardView = SessionCardView(
     locationLine = "unknown",
     startsAt = GMTDate.START,
     endsAt = GMTDate.START,
-    isLive = false,
     speakerIds = emptyList(),
-    isFinished = false,
     isFavorite = false,
-    isUpcoming = false,
     description = "unknown",
     vote = null,
     tags = emptyList(),
-    startsInMinutes = null
+    startsInMinutes = null,
+    state = SessionState.Upcoming,
 )
 
 val UNKNOWN_SPEAKER: Speaker = Speaker(

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/ConferenceService.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/ConferenceService.kt
@@ -28,9 +28,11 @@ val UNKNOWN_SESSION_CARD: SessionCardView = SessionCardView(
     speakerIds = emptyList(),
     isFinished = false,
     isFavorite = false,
+    isUpcoming = false,
     description = "unknown",
     vote = null,
-    tags = emptyList()
+    tags = emptyList(),
+    startsInMinutes = null
 )
 
 val UNKNOWN_SPEAKER: Speaker = Speaker(

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
@@ -22,24 +22,16 @@ data class SessionCardView(
     },
     val isFavorite: Boolean,
     val isFinished: Boolean,
+    val isUpcoming: Boolean,
     val description: String,
     val tags: List<String>,
     val badgeTimeLine: String = buildString {
         append(startsAt.time())
         append("-")
         append(endsAt.time())
-    }
-) {
-    val isBreak: Boolean = title == "Break" || title == "Breakfast" || title == "Coffee Break"
-
-    val isLunch: Boolean = title == "Lunch"
-
-    val isParty: Boolean = title.contains("Party")
-
-    val isLightning: Boolean = endsAt.timestamp - startsAt.timestamp <= 15 * 60 * 1000
-
-    val key: String =
-        "${startsAt.timestamp}-${endsAt.timestamp}-$title-$isBreak-$isParty-$isLunch-${startsAt.dayOfMonth}"
-}
+    },
+    val isLightning: Boolean = endsAt.timestamp - startsAt.timestamp <= 15 * 60 * 1000,
+    val startsInMinutes: Int?,
+)
 
 val Session.isLightning: Boolean get() = endsAt.timestamp - startsAt.timestamp <= 15 * 60 * 1000

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
@@ -1,7 +1,8 @@
 package org.jetbrains.kotlinconf
 
-import io.ktor.util.date.*
-import org.jetbrains.kotlinconf.utils.*
+import io.ktor.util.date.GMTDate
+import org.jetbrains.kotlinconf.utils.dayAndMonth
+import org.jetbrains.kotlinconf.utils.time
 
 data class SessionCardView(
     val id: SessionId,
@@ -10,7 +11,7 @@ data class SessionCardView(
     val locationLine: String,
     val startsAt: GMTDate,
     val endsAt: GMTDate,
-    val isLive: Boolean,
+    val state: SessionState,
     val speakerIds: List<SpeakerId>,
     val vote: Score?,
     val timeLine: String = buildString {
@@ -21,8 +22,6 @@ data class SessionCardView(
         append(endsAt.time())
     },
     val isFavorite: Boolean,
-    val isFinished: Boolean,
-    val isUpcoming: Boolean,
     val description: String,
     val tags: List<String>,
     val badgeTimeLine: String = buildString {
@@ -33,5 +32,9 @@ data class SessionCardView(
     val isLightning: Boolean = endsAt.timestamp - startsAt.timestamp <= 15 * 60 * 1000,
     val startsInMinutes: Int?,
 )
+
+val SessionCardView.isLive get() = state == SessionState.Live
+val SessionCardView.isUpcoming get() = state == SessionState.Upcoming
+val SessionCardView.isPast get() = state == SessionState.Past
 
 val Session.isLightning: Boolean get() = endsAt.timestamp - startsAt.timestamp <= 15 * 60 * 1000

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionState.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionState.kt
@@ -1,0 +1,18 @@
+package org.jetbrains.kotlinconf
+
+import io.ktor.util.date.GMTDate
+
+enum class SessionState {
+    Live,
+    Past,
+    Upcoming,
+    ;
+
+    companion object {
+        fun from(startsAt: GMTDate, endsAt: GMTDate, now: GMTDate): SessionState = when {
+            startsAt <= now && now < endsAt -> Live
+            endsAt <= now -> Past
+            else -> Upcoming
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
@@ -149,3 +149,12 @@ data class NewsDisplayItem(
     val title: String,
     val content: String,
 )
+
+data class ServiceEvent(
+    val id: String,
+    val title: String,
+    val startsAt: GMTDate,
+    val endsAt: GMTDate,
+    val isLive: Boolean,
+    val startsInMinutes: Int?,
+)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.SessionCardView
 import org.jetbrains.kotlinconf.SessionId
+import org.jetbrains.kotlinconf.SessionState
 import org.jetbrains.kotlinconf.ui.components.DayHeader
 import org.jetbrains.kotlinconf.ui.components.Divider
 import org.jetbrains.kotlinconf.ui.components.Emotion
@@ -401,11 +402,10 @@ private fun SessionCard(
         timeNote = session.startsInMinutes?.let { count ->
             stringResource(Res.string.schedule_in_x_minutes, count)
         },
-        status = when {
-            session.isFinished -> TalkStatus.Past
-            session.isLive -> TalkStatus.Now
-            session.isUpcoming -> TalkStatus.Upcoming
-            else -> TalkStatus.Upcoming // Shouldn't happen
+        status = when (session.state) {
+            SessionState.Live -> TalkStatus.Live
+            SessionState.Past -> TalkStatus.Past
+            SessionState.Upcoming -> TalkStatus.Upcoming
         },
         onSubmitFeedback = { emotion ->
             onSubmitFeedback(session.id, emotion)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -2,45 +2,22 @@ package org.jetbrains.kotlinconf.screens
 
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.animateBounds
-import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.FlingBehavior
-import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListPrefetchStrategy
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -50,6 +27,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.shared.generated.resources.Res
@@ -74,6 +52,7 @@ import org.jetbrains.kotlinconf.ui.components.MainHeaderTitleBar
 import org.jetbrains.kotlinconf.ui.components.NowButton
 import org.jetbrains.kotlinconf.ui.components.NowButtonState
 import org.jetbrains.kotlinconf.ui.components.ScrollIndicator
+import org.jetbrains.kotlinconf.ui.components.ServiceEvent
 import org.jetbrains.kotlinconf.ui.components.StyledText
 import org.jetbrains.kotlinconf.ui.components.Switcher
 import org.jetbrains.kotlinconf.ui.components.TalkCard
@@ -423,6 +402,14 @@ fun ScheduleList(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 12.dp, vertical = 8.dp)
+                    )
+                }
+
+                is ServiceEventItem -> {
+                    val event = item.value
+                    ServiceEvent(
+                        event = event,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -38,7 +38,6 @@ import kotlinconfapp.shared.generated.resources.schedule_in_x_minutes
 import kotlinconfapp.ui_components.generated.resources.bookmark_24
 import kotlinconfapp.ui_components.generated.resources.search_24
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.SessionCardView
 import org.jetbrains.kotlinconf.SessionId
@@ -400,7 +399,7 @@ private fun SessionCard(
         lightning = session.isLightning,
         time = session.badgeTimeLine,
         timeNote = session.startsInMinutes?.let { count ->
-            pluralStringResource(Res.plurals.schedule_in_x_minutes, count, count)
+            stringResource(Res.string.schedule_in_x_minutes, count)
         },
         status = when {
             session.isFinished -> TalkStatus.Past

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -40,6 +40,7 @@ import kotlinconfapp.ui_components.generated.resources.search_24
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.kotlinconf.SessionCardView
 import org.jetbrains.kotlinconf.SessionId
 import org.jetbrains.kotlinconf.ui.components.DayHeader
 import org.jetbrains.kotlinconf.ui.components.Divider
@@ -324,35 +325,12 @@ fun ScheduleList(
                             modifier = Modifier.fillMaxWidth(),
                             beyondViewportPageCount = 20,
                         ) { page ->
-                            val session = workshops[page]
-                            TalkCard(
-                                title = session.title,
-                                titleHighlights = emptyList(),
-                                bookmarked = session.isFavorite,
-                                onBookmark = { isBookmarked -> onBookmark(session.id, isBookmarked) },
-                                tags = session.tags,
-                                tagHighlights = emptyList(),
-                                speakers = session.speakerLine,
-                                speakerHighlights = emptyList(),
-                                location = session.locationLine,
-                                lightning = session.isLightning,
-                                time = session.badgeTimeLine,
-                                timeNote = session.startsInMinutes?.let { count ->
-                                    pluralStringResource(Res.plurals.schedule_in_x_minutes, count, count)
-                                },
-                                status = when {
-                                    session.isFinished -> TalkStatus.Past
-                                    session.isLive -> TalkStatus.Now
-                                    session.isUpcoming -> TalkStatus.Upcoming
-                                    else -> TalkStatus.Upcoming // Shouldn't happen
-                                },
-                                onSubmitFeedback = { emotion ->
-                                    onSubmitFeedback(session.id, emotion)
-                                },
-                                onSubmitFeedbackWithComment = { emotion, comment ->
-                                    onSubmitFeedbackWithComment(session.id, emotion, comment)
-                                },
-                                onClick = { onSession(session.id) },
+                            SessionCard(
+                                session = workshops[page],
+                                onBookmark = onBookmark,
+                                onSubmitFeedback = onSubmitFeedback,
+                                onSubmitFeedbackWithComment = onSubmitFeedbackWithComment,
+                                onSession = onSession,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .wrapContentHeight(Alignment.Top)
@@ -370,35 +348,15 @@ fun ScheduleList(
                 }
 
                 is SessionItem -> {
-                    val session = item.value
-                    TalkCard(
-                        title = session.title,
+                    SessionCard(
+                        session = item.value,
                         titleHighlights = item.titleHighlights,
-                        bookmarked = session.isFavorite,
-                        onBookmark = { isBookmarked -> onBookmark(session.id, isBookmarked) },
-                        tags = session.tags,
                         tagHighlights = item.tagMatches,
-                        speakers = session.speakerLine,
                         speakerHighlights = item.speakerHighlights,
-                        location = session.locationLine,
-                        lightning = session.isLightning,
-                        time = session.badgeTimeLine,
-                        timeNote = session.startsInMinutes?.let { count ->
-                            pluralStringResource(Res.plurals.schedule_in_x_minutes, count, count)
-                        },
-                        status = when {
-                            session.isFinished -> TalkStatus.Past
-                            session.isLive -> TalkStatus.Now
-                            session.isUpcoming -> TalkStatus.Upcoming
-                            else -> TalkStatus.Upcoming // Shouldn't happen
-                        },
-                        onSubmitFeedback = { emotion ->
-                            onSubmitFeedback(session.id, emotion)
-                        },
-                        onSubmitFeedbackWithComment = { emotion, comment ->
-                            onSubmitFeedbackWithComment(session.id, emotion, comment)
-                        },
-                        onClick = { onSession(session.id) },
+                        onBookmark = onBookmark,
+                        onSubmitFeedback = onSubmitFeedback,
+                        onSubmitFeedbackWithComment = onSubmitFeedbackWithComment,
+                        onSession = onSession,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 12.dp, vertical = 8.dp)
@@ -415,4 +373,48 @@ fun ScheduleList(
             }
         }
     }
+}
+
+@Composable
+private fun SessionCard(
+    session: SessionCardView,
+    onBookmark: (SessionId, Boolean) -> Unit,
+    onSubmitFeedback: (SessionId, Emotion?) -> Unit,
+    onSubmitFeedbackWithComment: (SessionId, Emotion, String) -> Unit,
+    onSession: (SessionId) -> Unit,
+    modifier: Modifier = Modifier,
+    titleHighlights: List<IntRange> = emptyList(),
+    tagHighlights: List<String> = emptyList(),
+    speakerHighlights: List<IntRange> = emptyList(),
+) {
+    TalkCard(
+        title = session.title,
+        titleHighlights = titleHighlights,
+        bookmarked = session.isFavorite,
+        onBookmark = { isBookmarked -> onBookmark(session.id, isBookmarked) },
+        tags = session.tags,
+        tagHighlights = tagHighlights,
+        speakers = session.speakerLine,
+        speakerHighlights = speakerHighlights,
+        location = session.locationLine,
+        lightning = session.isLightning,
+        time = session.badgeTimeLine,
+        timeNote = session.startsInMinutes?.let { count ->
+            pluralStringResource(Res.plurals.schedule_in_x_minutes, count, count)
+        },
+        status = when {
+            session.isFinished -> TalkStatus.Past
+            session.isLive -> TalkStatus.Now
+            session.isUpcoming -> TalkStatus.Upcoming
+            else -> TalkStatus.Upcoming // Shouldn't happen
+        },
+        onSubmitFeedback = { emotion ->
+            onSubmitFeedback(session.id, emotion)
+        },
+        onSubmitFeedbackWithComment = { emotion, comment ->
+            onSubmitFeedbackWithComment(session.id, emotion, comment)
+        },
+        onClick = { onSession(session.id) },
+        modifier = modifier,
+    )
 }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -29,9 +29,11 @@ import kotlinconfapp.shared.generated.resources.Res
 import kotlinconfapp.shared.generated.resources.nav_destination_schedule
 import kotlinconfapp.shared.generated.resources.schedule_action_filter_bookmarked
 import kotlinconfapp.shared.generated.resources.schedule_action_search
+import kotlinconfapp.shared.generated.resources.schedule_in_x_minutes
 import kotlinconfapp.ui_components.generated.resources.bookmark_24
 import kotlinconfapp.ui_components.generated.resources.search_24
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.SessionId
 import org.jetbrains.kotlinconf.ui.components.DayHeader
@@ -91,10 +93,10 @@ fun ScheduleScreen(
 
 
     val firstLiveIndex = remember(items) {
-        items.indexOfFirst { it.isLive() }
+        items.indexOfFirst { it.isLive() || it.isUpcoming() }
     }
     val lastLiveIndex = remember(items) {
-        items.indexOfLast { it.isLive() }
+        items.indexOfLast { it.isLive() || it.isUpcomingSoon() }
     }
     var nowScrolling by remember { mutableStateOf(false) }
     val nowButtonState: NowButtonState? by derivedStateOf {
@@ -319,11 +321,14 @@ fun ScheduleList(
                         location = session.locationLine,
                         lightning = session.isLightning,
                         time = session.badgeTimeLine,
-                        timeNote = null,
+                        timeNote = session.startsInMinutes?.let { count ->
+                            pluralStringResource(Res.plurals.schedule_in_x_minutes, count, count)
+                        },
                         status = when {
                             session.isFinished -> TalkStatus.Past
                             session.isLive -> TalkStatus.Now
-                            else -> TalkStatus.Upcoming
+                            session.isUpcoming -> TalkStatus.Upcoming
+                            else -> TalkStatus.Upcoming // Shouldn't happen
                         },
                         onSubmitFeedback = { emotion ->
                             onSubmitFeedback(session.id, emotion)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
@@ -145,10 +145,6 @@ class ScheduleViewModel(
             initialValue = emptyList()
         )
 
-    /**
-     * Builds a flat list of items for the UI, taking into account the current
-     * filtering values and active filters.
-     */
     private fun buildItems(
         days: List<Day>,
         searchParams: ScheduleSearchParams,
@@ -156,76 +152,74 @@ class ScheduleViewModel(
     ): List<ScheduleListItem> {
         val tagValues = tags.filter { it.isSelected }.map { it.value }
 
-        return buildList {
-            days.forEach { day ->
-                if (!searchParams.isSearch) add(DayHeaderItem(day))
+        return if (searchParams.isSearch) {
+            buildSearchItems(days, searchParams.searchQuery, tagValues)
+        } else {
+            buildNonSearchItems(days, searchParams.isBookmarkedOnly)
+        }
+    }
 
-                day.timeSlots.forEach { timeSlot ->
-                    if (!searchParams.isSearch) {
-                        add(TimeSlotTitleItem(timeSlot))
-                    }
-
-                    if (!searchParams.isSearch) {
-                        val (workshops, talks) = timeSlot.sessions.partition { it.tags.contains("Workshop") }
-                        if (workshops.isNotEmpty()) {
-                            add(WorkshopItem(workshops))
-                        }
-                        talks.forEach { session ->
-                            if (searchParams.isSearch) {
-                                val result = this@ScheduleViewModel.match(
-                                    session = session,
-                                    searchQuery = searchParams.searchQuery,
-                                    tags = tagValues,
-                                )
-                                if (result.matched) {
-                                    add(
-                                        SessionItem(
-                                            value = session,
-                                            tagMatches = result.tagMatches,
-                                            titleHighlights = result.titleHighlights,
-                                            speakerHighlights = result.speakerHighlights,
-                                        )
-                                    )
-                                }
-                            } else {
-                                if (!searchParams.isBookmarkedOnly || session.isFavorite) {
-                                    add(SessionItem(session))
-                                }
-                            }
-                        }
-                    }
-
-                    val talks = timeSlot.sessions
-
-                    talks.forEach { session ->
-                        if (searchParams.isSearch) {
-                            val result = this@ScheduleViewModel.match(
-                                session = session,
-                                searchQuery = searchParams.searchQuery,
-                                tags = tagValues,
+    private fun buildSearchItems(
+        days: List<Day>,
+        searchQuery: String,
+        tagValues: List<String>,
+    ): List<ScheduleListItem> = buildList {
+        days.forEach { day ->
+            day.timeSlots.forEach { timeSlot ->
+                timeSlot.sessions.forEach { session ->
+                    val result = match(
+                        session = session,
+                        searchQuery = searchQuery,
+                        tags = tagValues,
+                    )
+                    if (result.matched) {
+                        add(
+                            SessionItem(
+                                value = session,
+                                tagMatches = result.tagMatches,
+                                titleHighlights = result.titleHighlights,
+                                speakerHighlights = result.speakerHighlights,
                             )
-                            if (result.matched) {
-                                add(
-                                    SessionItem(
-                                        value = session,
-                                        tagMatches = result.tagMatches,
-                                        titleHighlights = result.titleHighlights,
-                                        speakerHighlights = result.speakerHighlights,
-                                    )
-                                )
-                            }
-                        } else {
-                            if (!searchParams.isBookmarkedOnly || session.isFavorite) {
-                                add(SessionItem(session))
-                            }
-                        }
-                    }
-
-                    // If the timeslot doesn't have any sessions, remove its title
-                    if (!searchParams.isSearch && last() is TimeSlotTitleItem) {
-                        removeLast()
+                        )
                     }
                 }
+            }
+        }
+    }
+
+    private fun buildNonSearchItems(
+        days: List<Day>,
+        isBookmarkedOnly: Boolean,
+    ): List<ScheduleListItem> = buildList {
+        days.forEach { day ->
+            add(DayHeaderItem(day))
+
+            day.timeSlots.forEach { timeSlot ->
+                add(TimeSlotTitleItem(timeSlot))
+
+                val sessions = if (isBookmarkedOnly) {
+                    timeSlot.sessions.filter { it.isFavorite }
+                } else {
+                    timeSlot.sessions
+                }
+
+                val (workshops, talks) = sessions.partition { it.tags.contains("Workshop") }
+                if (workshops.isNotEmpty()) {
+                    add(WorkshopItem(workshops))
+                }
+                talks.forEach { session ->
+                    add(SessionItem(session))
+                }
+
+                // Remove empty time slots
+                if (last() is TimeSlotTitleItem) {
+                    removeLast()
+                }
+            }
+
+            // Remove empty days
+            if (last() is DayHeaderItem) {
+                removeLast()
             }
         }
     }
@@ -247,10 +241,10 @@ class ScheduleViewModel(
         val titleHighlights = mutableListOf<IntRange>()
         val speakerHighlights = mutableListOf<IntRange>()
 
-        // TODO clarify requirements for tag filtering
         if (tags.isNotEmpty()) {
-            tagMatches.addAll(session.tags.filter { it in tags })
-            if (tagMatches.isEmpty()) {
+            if (session.tags.containsAll(tags)) {
+                tagMatches.addAll(tags)
+            } else {
                 return MatchResult(matched = false)
             }
         }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
@@ -19,6 +19,8 @@ import org.jetbrains.kotlinconf.Score
 import org.jetbrains.kotlinconf.SessionCardView
 import org.jetbrains.kotlinconf.SessionId
 import org.jetbrains.kotlinconf.TimeSlot
+import org.jetbrains.kotlinconf.isLive
+import org.jetbrains.kotlinconf.isUpcoming
 import org.jetbrains.kotlinconf.ui.components.Emotion
 import org.jetbrains.kotlinconf.ui.components.FilterItem
 import org.jetbrains.kotlinconf.ui.components.FilterItemType

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
@@ -22,19 +22,25 @@ import org.jetbrains.kotlinconf.TimeSlot
 import org.jetbrains.kotlinconf.ui.components.Emotion
 import org.jetbrains.kotlinconf.ui.components.FilterItem
 import org.jetbrains.kotlinconf.ui.components.FilterItemType
+import org.jetbrains.kotlinconf.ui.components.ServiceEventData
 import org.jetbrains.kotlinconf.utils.containsDiacritics
 import org.jetbrains.kotlinconf.utils.removeDiacritics
 
 sealed interface ScheduleListItem
 
-// TODO add service events
 data class DayHeaderItem(val value: Day) : ScheduleListItem
+
 data class TimeSlotTitleItem(val value: TimeSlot) : ScheduleListItem
+
 data class SessionItem(
     val value: SessionCardView,
     val tagMatches: List<String> = emptyList(),
     val titleHighlights: List<IntRange> = emptyList(),
     val speakerHighlights: List<IntRange> = emptyList(),
+) : ScheduleListItem
+
+data class ServiceEventItem(
+    val value: ServiceEventData,
 ) : ScheduleListItem
 
 data class WorkshopItem(
@@ -187,6 +193,7 @@ class ScheduleViewModel(
         }
     }
 
+    // TODO add ServiceEventItems to this list https://github.com/JetBrains/kotlinconf-app/issues/269
     private fun buildNonSearchItems(
         days: List<Day>,
         isBookmarkedOnly: Boolean,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
@@ -38,8 +38,15 @@ data class SessionItem(
     val speakerHighlights: List<IntRange> = emptyList(),
 ) : ScheduleListItem
 
+
 fun ScheduleListItem.isLive(): Boolean =
     (this is SessionItem && this.value.isLive) || (this is TimeSlotTitleItem && this.value.isLive)
+
+fun ScheduleListItem.isUpcoming(): Boolean =
+    (this is SessionItem && this.value.isUpcoming) || (this is TimeSlotTitleItem && this.value.isUpcoming)
+
+fun ScheduleListItem.isUpcomingSoon(): Boolean =
+    (this is SessionItem && this.value.isUpcoming && this.value.startsInMinutes != null )
 
 // TODO get set of tags from the service
 private val categoryTags = listOf(

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
@@ -45,6 +45,7 @@ import kotlinconfapp.shared.generated.resources.session_your_feedback
 import kotlinconfapp.shared.generated.resources.up_24
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.SessionId
+import org.jetbrains.kotlinconf.SessionState
 import org.jetbrains.kotlinconf.ui.components.Action
 import org.jetbrains.kotlinconf.ui.components.ActionSize
 import org.jetbrains.kotlinconf.ui.components.Divider
@@ -111,7 +112,7 @@ fun SessionScreen(
                 modifier = Modifier.padding(vertical = 24.dp),
             )
 
-            if (session.isFinished || session.isLive) {
+            if (session.state != SessionState.Upcoming) {
                 FeedbackPanel(
                     onFeedback = { emotion ->
                         viewModel.submitFeedback(emotion)

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/ServiceEvents.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/ServiceEvents.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
 import org.jetbrains.kotlinconf.ui.theme.PreviewHelper
 
 data class ServiceEventData(
-    val name: String,
+    val title: String,
     val now: Boolean,
     val note: String? = null,
     val time: String? = null,
@@ -34,7 +34,7 @@ private fun ServiceEventItem(
         modifier = modifier.padding(16.dp)
     ) {
         StyledText(
-            text = event.name,
+            text = event.title,
             style = KotlinConfTheme.typography.h3,
             color = KotlinConfTheme.colors.primaryText,
         )
@@ -101,7 +101,7 @@ internal fun ServiceEventsPreview() {
     PreviewHelper {
         ServiceEvent(
             ServiceEventData(
-                name = "Breakfast",
+                title = "Breakfast",
                 now = false,
                 time = "9:00 – 10:00",
             )
@@ -109,18 +109,18 @@ internal fun ServiceEventsPreview() {
         ServiceEvents(
             listOf(
                 ServiceEventData(
-                    name = "Lunch",
+                    title = "Lunch",
                     now = false,
                     time = "12:00 – 13:00",
                     note = "In 30 min",
                 ),
                 ServiceEventData(
-                    name = "Dinner",
+                    title = "Dinner",
                     now = true,
                     time = "17:00 – 18:00",
                 ),
                 ServiceEventData(
-                    name = "Party",
+                    title = "Party",
                     now = false,
                 )
             )

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
@@ -81,7 +81,7 @@ private fun buildHighlightedString(
 }
 
 enum class TalkStatus {
-    Past, Now, Upcoming,
+    Past, Live, Upcoming,
 }
 
 private val CardTalkShape = RoundedCornerShape(8.dp)
@@ -263,7 +263,7 @@ private fun TimeBlock(
             )
         }
 
-        if (status == TalkStatus.Now) {
+        if (status == TalkStatus.Live) {
             NowLabel()
         }
 
@@ -391,7 +391,7 @@ internal fun TalkCardPreview() {
                 lightning = true,
                 time = "9:00 – 10:00",
                 timeNote = null,
-                status = TalkStatus.Now,
+                status = TalkStatus.Live,
                 onSubmitFeedbackWithComment = { e, s -> println("Feedback, emotion + comment: $e, $s") },
                 onSubmitFeedback = { e -> println("Feedback, emotion only: $e") },
                 onClick = { "Clicked session" },


### PR DESCRIPTION
Adds the following:

- Displaying when a session is coming up soon
- Highlighting workshops in a separate scroller at the top
- Service events (except #269 which will add actual data)

TODOs remaining on this screen:

- #269 
- Filtering tags being based on real data instead of hardcoded values
- Improvements on date and string handling (currently too hardcoded)
- State preservation around navigation


https://github.com/user-attachments/assets/2820a91d-7e7a-4b6d-9e4b-74642d3b2f43

