### PR TITLE
Add per-screen edge-to-edge support

### DIFF
--- a/androidApp/src/androidMain/kotlin/org/jetbrains/kotlinconf/android/MainActivity.kt
+++ b/androidApp/src/androidMain/kotlin/org/jetbrains/kotlinconf/android/MainActivity.kt
@@ -1,14 +1,11 @@
 package org.jetbrains.kotlinconf.android
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.jetbrains.kotlinconf.R
 import org.jetbrains.kotlinconf.App
@@ -25,10 +22,19 @@ class MainActivity : ComponentActivity() {
             R.mipmap.ic_launcher,
         )
 
-        enableEdgeToEdge()
-
         setContent {
-            App(context)
+            App(
+                context = context,
+                onThemeChange = { isDarkMode ->
+                    enableEdgeToEdge(
+                        statusBarStyle = SystemBarStyle.auto(
+                            lightScrim = Color.TRANSPARENT,
+                            darkScrim = Color.TRANSPARENT,
+                            detectDarkMode = { isDarkMode }
+                        )
+                    )
+                },
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
@@ -3,10 +3,7 @@ package org.jetbrains.kotlinconf
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -52,7 +49,6 @@ fun App(context: ApplicationContext) {
                     Modifier
                         .fillMaxSize()
                         .background(KotlinConfTheme.colors.mainBackground)
-                        .windowInsetsPadding(WindowInsets.safeDrawing)
                 ) {
                     if (isOnboardingComplete != null) {
                         KotlinConfNavHost(isOnboardingComplete)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -29,7 +30,10 @@ import org.koin.dsl.koinConfiguration
 import org.koin.dsl.module
 
 @Composable
-fun App(context: ApplicationContext) {
+fun App(
+    context: ApplicationContext,
+    onThemeChange: ((isDarkTheme: Boolean) -> Unit)? = null,
+) {
     KoinMultiplatformApplication(koinConfiguration(context)) {
         DevelopmentEntryPoint {
             val service = koinInject<ConferenceService>()
@@ -38,6 +42,10 @@ fun App(context: ApplicationContext) {
                 Theme.SYSTEM -> isSystemInDarkTheme()
                 Theme.LIGHT -> false
                 Theme.DARK -> true
+            }
+
+            if (onThemeChange != null) {
+                LaunchedEffect(isDarkTheme) { onThemeChange(isDarkTheme) }
             }
 
             val isOnboardingComplete = service.isOnboardingComplete()

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/BaseScreens.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/BaseScreens.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlinconf.ui.components.MarkdownView
 import org.jetbrains.kotlinconf.ui.components.StyledText
 import org.jetbrains.kotlinconf.ui.components.TopMenuButton
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
+import org.jetbrains.kotlinconf.utils.topInsetPadding
 
 @Composable
 fun ScreenWithTitle(
@@ -28,7 +29,11 @@ fun ScreenWithTitle(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    Column(modifier.fillMaxSize()) {
+    Column(
+        modifier
+            .fillMaxSize()
+            .padding(topInsetPadding())
+    ) {
         MainHeaderTitleBar(
             title = title,
             startContent = {

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/LicenseScreens.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/LicenseScreens.kt
@@ -32,6 +32,8 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.ScreenWithTitle
 import org.jetbrains.kotlinconf.ui.components.StyledText
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
+import org.jetbrains.kotlinconf.utils.bottomInsetPadding
+import org.jetbrains.kotlinconf.utils.plus
 
 private val Library.licenseName: String
     get() = licenses.firstOrNull()?.name ?: "Unknown license"
@@ -83,7 +85,7 @@ fun SingleLicenseScreen(
             licenseContent,
             style = KotlinConfTheme.typography.text2,
             color = KotlinConfTheme.colors.noteText,
-            modifier = Modifier.padding(vertical = 12.dp),
+            modifier = Modifier.padding(PaddingValues(vertical = 12.dp) + bottomInsetPadding()),
         )
     }
 }
@@ -102,7 +104,7 @@ private fun LibraryList(
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(vertical = 16.dp),
+        contentPadding = PaddingValues(vertical = 16.dp) + bottomInsetPadding(),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         items(sortedLibraries) { library ->

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/MainScreen.kt
@@ -1,8 +1,11 @@
 package org.jetbrains.kotlinconf.screens
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -59,12 +62,18 @@ fun MainScreen(
         service.completeOnboarding()
     }
 
-    Column(Modifier.fillMaxSize()) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
+    ) {
         val nestedNavController = rememberNavController()
         NavHost(
             nestedNavController,
             startDestination = ScheduleScreen,
-            modifier = Modifier.fillMaxWidth().weight(1f),
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
         ) {
             composable<InfoScreen> {
                 val uriHandler = LocalUriHandler.current

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/NewsListScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/NewsListScreen.kt
@@ -14,6 +14,8 @@ import kotlinconfapp.shared.generated.resources.news_feed_title
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.ScreenWithTitle
 import org.jetbrains.kotlinconf.ui.components.NewsCard
+import org.jetbrains.kotlinconf.utils.bottomInsetPadding
+import org.jetbrains.kotlinconf.utils.plus
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -27,9 +29,10 @@ fun NewsListScreen(
         onBack = onBack,
     ) {
         val news by viewModel.news.collectAsState()
+
         LazyColumn(
             modifier = Modifier.weight(1f),
-            contentPadding = PaddingValues(vertical = 16.dp),
+            contentPadding = PaddingValues(vertical = 16.dp) + bottomInsetPadding(),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             items(news) { newsItem ->

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/PrivacyPolicyScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/PrivacyPolicyScreen.kt
@@ -10,9 +10,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -68,6 +71,7 @@ fun PrivacyPolicyScreen(
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)
     ) {
         AnimatedContent(
             targetState = detailsVisible,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
@@ -58,6 +58,7 @@ import org.jetbrains.kotlinconf.ui.components.SpeakerCard
 import org.jetbrains.kotlinconf.ui.components.StyledText
 import org.jetbrains.kotlinconf.ui.components.TopMenuButton
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
+import org.jetbrains.kotlinconf.utils.topInsetPadding
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -80,7 +81,11 @@ fun SessionScreen(
         }
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(topInsetPadding())
+    ) {
         MainHeaderTitleBar(
             title = stringResource(Res.string.session_title),
             startContent = {

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinconf.screens
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.EaseOutQuad
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
@@ -78,7 +79,7 @@ fun SettingsScreen(
                 scope.launch {
                     bitmap = graphicsLayer.toImageBitmap()
                     bitmapVisibility.snapTo(1f)
-                    bitmapVisibility.animateTo(0f, tween(500))
+                    bitmapVisibility.animateTo(0f, tween(800, easing = EaseOutQuad))
                     bitmap = null
                 }
                 viewModel.setTheme(theme)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/StartNotificationsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/StartNotificationsScreen.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -36,7 +39,11 @@ fun StartNotificationsScreen(
 ) {
     val notificationSettings by viewModel.notificationSettings.collectAsStateWithLifecycle()
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
+    ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(24.dp),
             modifier = Modifier

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/utils/PaddingValues.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/utils/PaddingValues.kt
@@ -1,0 +1,29 @@
+package org.jetbrains.kotlinconf.utils
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalLayoutDirection
+
+@Composable
+fun bottomInsetPadding() = WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom).asPaddingValues()
+
+@Composable
+fun topInsetPadding() = WindowInsets.safeDrawing.only(WindowInsetsSides.Top).asPaddingValues()
+
+@Composable
+operator fun PaddingValues.plus(other: PaddingValues): PaddingValues {
+    val layoutDir = LocalLayoutDirection.current
+    return PaddingValues(
+        start = calculateStartPadding(layoutDir) + other.calculateStartPadding(layoutDir),
+        top = calculateTopPadding() + other.calculateTopPadding(),
+        end = calculateEndPadding(layoutDir) + other.calculateEndPadding(layoutDir),
+        bottom = calculateBottomPadding() + other.calculateBottomPadding()
+    )
+}


### PR DESCRIPTION
Tweaks edge-to-edge implementation by adding the appropriate padding on each screen separately. This makes sure that, for example, scrollable content can also fill the entire screen.

https://github.com/user-attachments/assets/1f02b058-0af9-42f2-8e8c-9dda31e2c1c0

