### PR TITLE
Add storage versioning

### DIFF
--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/storage/ApplicationStorage.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/storage/ApplicationStorage.kt
@@ -28,4 +28,6 @@ interface ApplicationStorage {
 
     fun getNotificationSettings(): Flow<NotificationSettings>
     suspend fun setNotificationSettings(value: NotificationSettings)
+
+    fun ensureCurrentVersion()
 }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/storage/MultiplatformSettingsStorage.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/storage/MultiplatformSettingsStorage.kt
@@ -7,7 +7,6 @@ import com.russhwolf.settings.coroutines.getStringOrNullFlow
 import com.russhwolf.settings.set
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jetbrains.kotlinconf.Conference
 import org.jetbrains.kotlinconf.NewsItem
@@ -25,35 +24,55 @@ class MultiplatformSettingsStorage(
     override fun isOnboardingComplete(): Flow<Boolean> = settings.getBooleanFlow(Keys.ONBOARDING_COMPLETE, false)
     override suspend fun setOnboardingComplete(value: Boolean) = settings.set(Keys.ONBOARDING_COMPLETE, value)
 
-    override fun getTheme(): Flow<Theme> = settings.getStringOrNullFlow(Keys.THEME).map { it?.let { Theme.valueOf(it) } ?: Theme.SYSTEM }
-    override suspend fun setTheme(value: Theme) = settings.set(Keys.THEME, value.name)
+    override fun getTheme(): Flow<Theme> = settings.getStringOrNullFlow(Keys.THEME)
+        .map { it?.let { Theme.valueOf(it) } ?: Theme.SYSTEM }
 
-    override fun getConferenceCache(): Flow<Conference> = settings.getStringOrNullFlow(Keys.CONFERENCE_CACHE).map { it?.let { Json.decodeFromString<Conference>(it) } ?: Conference() }
-    override suspend fun setConferenceCache(value: Conference) = settings.set(
-        Keys.CONFERENCE_CACHE,
-        Json.encodeToString(value)
-    )
+    override suspend fun setTheme(value: Theme) = settings
+        .set(Keys.THEME, value.name)
 
-    override fun getFavorites(): Flow<Set<SessionId>> = settings.getStringOrNullFlow(Keys.FAVORITES).map { it?.let { Json.decodeFromString<Set<SessionId>>(it) } ?: emptySet() }
-    override suspend fun setFavorites(value: Set<SessionId>) = settings.set(Keys.FAVORITES, Json.encodeToString(value))
+    override fun getConferenceCache(): Flow<Conference> = settings.getStringOrNullFlow(Keys.CONFERENCE_CACHE)
+        .map { it?.let { Json.decodeFromString<Conference>(it) } ?: Conference() }
+
+    override suspend fun setConferenceCache(value: Conference) = settings
+        .set(Keys.CONFERENCE_CACHE, Json.encodeToString(value))
+
+    override fun getFavorites(): Flow<Set<SessionId>> = settings.getStringOrNullFlow(Keys.FAVORITES)
+        .map { it?.let { Json.decodeFromString<Set<SessionId>>(it) } ?: emptySet() }
+
+    override suspend fun setFavorites(value: Set<SessionId>) = settings
+        .set(Keys.FAVORITES, Json.encodeToString(value))
 
     override fun getNews(): Flow<List<NewsItem>> = settings.getStringOrNullFlow(Keys.NEWS_CACHE)
         .map { it?.let { Json.decodeFromString<List<NewsItem>>(it) } ?: emptyList() }
 
-    override suspend fun setNews(value: List<NewsItem>) = settings.set(
-        Keys.NEWS_CACHE,
-        Json.encodeToString(value)
-    )
+    override suspend fun setNews(value: List<NewsItem>) = settings
+        .set(Keys.NEWS_CACHE, Json.encodeToString(value))
 
     override fun getNotificationSettings(): Flow<NotificationSettings> =
         settings.getStringOrNullFlow(Keys.NOTIFICATION_SETTINGS)
-            .map { it?.let { Json.decodeFromString<NotificationSettings>(it) } ?: NotificationSettings(true, true, true) }
-    override suspend fun setNotificationSettings(value: NotificationSettings) = settings.set(
-        Keys.NOTIFICATION_SETTINGS,
-        Json.encodeToString(value)
-    )
+            .map {
+                it?.let { Json.decodeFromString<NotificationSettings>(it) }
+                    ?: NotificationSettings(true, true, true)
+            }
+
+    override suspend fun setNotificationSettings(value: NotificationSettings) = settings
+        .set(Keys.NOTIFICATION_SETTINGS, Json.encodeToString(value))
+
+    override fun ensureCurrentVersion() {
+        val version = settings.getInt(Keys.STORAGE_VERSION, 0)
+        if (version < CURRENT_STORAGE_VERSION) {
+            // Fully destructive migration on version mismatch
+            settings.clear()
+            settings.set(Keys.STORAGE_VERSION, CURRENT_STORAGE_VERSION)
+        }
+    }
+
+    private companion object {
+        const val CURRENT_STORAGE_VERSION: Int = 2025_000
+    }
 
     private object Keys {
+        const val STORAGE_VERSION = "storageVersion"
         const val USER_ID = "userid2025"
         const val ONBOARDING_COMPLETE = "onboardingComplete"
         const val THEME = "theme"


### PR DESCRIPTION
Keep track of current storage version. If we see an older storage version (uninitialized at the moment means it's from before 2025), we destructively migrate to the new version.

Later on, as the storage schema changes, we can create more sophisticated migrations based on the stored and current storage versions.

Fixes [#306](https://github.com/JetBrains/kotlinconf-app/issues/306)