### PR TITLE
Remove extra loading state from session detail screen

### DIFF
--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionViewModel.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.jetbrains.kotlinconf.ConferenceService
@@ -16,12 +15,6 @@ import org.jetbrains.kotlinconf.SessionId
 import org.jetbrains.kotlinconf.Speaker
 import org.jetbrains.kotlinconf.ui.components.Emotion
 
-sealed class SessionUiState {
-    data object Loading : SessionUiState()
-    data object Error : SessionUiState()
-    data class Content(val session: SessionCardView, val speakers: List<Speaker>) : SessionUiState()
-}
-
 class SessionViewModel(
     private val service: ConferenceService,
     private val sessionId: SessionId,
@@ -30,15 +23,11 @@ class SessionViewModel(
     private val _navigateToPrivacyPolicy = MutableStateFlow(false)
     val navigateToPrivacyPolicy: StateFlow<Boolean> = _navigateToPrivacyPolicy.asStateFlow()
 
-    val uiState: StateFlow<SessionUiState> = combine(
-        service.sessionByIdFlow(sessionId),
-        service.speakersBySessionId(sessionId),
-    ) { session, speakers ->
-        when {
-            session == null -> SessionUiState.Error
-            else -> SessionUiState.Content(session, speakers)
-        }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SessionUiState.Loading)
+    val session: StateFlow<SessionCardView?> = service.sessionByIdFlow(sessionId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    val speakers: StateFlow<List<Speaker>> = service.speakersBySessionId(sessionId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     fun toggleFavorite(isBookmarked: Boolean) {
         viewModelScope.launch {


### PR DESCRIPTION
This loading state will almost never be displayed, as we're loading local data, but it causes some UI glitches that we'd otherwise have to fix