### PR TITLE
Only use the description of the first workshop part when merging workshops

### DIFF
--- a/backend/src/main/kotlin/org/jetbrains/kotlinconf/backend/services/SessionizeService.kt
+++ b/backend/src/main/kotlin/org/jetbrains/kotlinconf/backend/services/SessionizeService.kt
@@ -116,7 +116,7 @@ class SessionizeService(
             Session(
                 first.id,
                 title,
-                parts.joinToString("\n") { it.description },
+                first.description,
                 parts.flatMap { it.speakerIds }.distinct(),
                 first.location,
                 startTime,


### PR DESCRIPTION
Currently we're creating workshop sessions that include the description 4 times in a row