### PR TITLE
Improve iOS keyboard handling, add feedback and keyboard behavior flags

### DIFF
--- a/shared/src/commonMain/composeResources/drawable/play_video.xml
+++ b/shared/src/commonMain/composeResources/drawable/play_video.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19.653,9.886C21.207,10.867 21.207,13.132 19.653,14.113L7.835,21.577C6.17,22.629 4,21.433 4,19.464L4,4.535C4,2.566 6.17,1.37 7.835,2.422L19.653,9.886Z"
+      android:fillColor="#FF0052"/>
+</vector>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -119,6 +119,7 @@ We will process your data in accordance with the App Privacy Policy. You can adj
     <string name="session_title">Schedule</string>
     <string name="session_your_feedback">Your feedback</string>
     <string name="session_screen_error">The details of this session are not available at the moment.</string>
+    <string name="session_watch_video">Watch the recording</string>
 
     <string name="map_title">Map</string>
     <string name="map_ground_floor">Ground floor</string>

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/App.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavBackStackEntry
 import org.jetbrains.kotlinconf.navigation.KotlinConfNavHost
+import org.jetbrains.kotlinconf.storage.ApplicationStorage
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
 import org.koin.compose.koinInject
 import kotlin.jvm.JvmSuppressWildcards
@@ -41,7 +42,8 @@ fun App(
         .collectAsStateWithLifecycle(initialValue = null)
         .value
 
-    CompositionLocalProvider(LocalFlags provides koinInject()) {
+    val flags by koinInject<FlagsManager>().flags.collectAsStateWithLifecycle()
+    CompositionLocalProvider(LocalFlags provides flags) {
         KotlinConfTheme(
             darkTheme = isDarkTheme,
             rippleEnabled = LocalFlags.current.rippleEnabled,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/ConferenceService.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/ConferenceService.kt
@@ -147,9 +147,6 @@ class ConferenceService(
         }
     }
 
-    /**
-     * Returns true if app is launched first time.
-     */
     fun isOnboardingComplete(): Flow<Boolean> {
         return storage.isOnboardingComplete()
     }
@@ -230,9 +227,6 @@ class ConferenceService(
         return client.userId != null
     }
 
-    /**
-     * Vote for session.
-     */
     suspend fun vote(sessionId: SessionId, rating: Score?): Boolean {
         if (!checkUserId()) return false
 
@@ -274,9 +268,6 @@ class ConferenceService(
             allNews.find { it.id == newsId }
         }
 
-    /**
-     * Mark session as favorite.
-     */
     fun setFavorite(sessionId: SessionId, favorite: Boolean) {
         scope.launch {
             val favorites = storage.getFavorites().first().toMutableSet()

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/Flags.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/Flags.kt
@@ -7,6 +7,7 @@ data class Flags(
     val supportsNotifications: Boolean = true,
     val rippleEnabled: Boolean = true,
     val redirectFeedbackToSessionPage: Boolean = false,
+    val hideKeyboardOnDrag: Boolean = false,
 )
 
 val LocalFlags = compositionLocalOf<Flags> {

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/Flags.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/Flags.kt
@@ -1,15 +1,20 @@
 package org.jetbrains.kotlinconf
 
 import androidx.compose.runtime.compositionLocalOf
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class Flags(
     val enableBackOnMainScreens: Boolean = true,
     val supportsNotifications: Boolean = true,
     val rippleEnabled: Boolean = true,
     val redirectFeedbackToSessionPage: Boolean = false,
     val hideKeyboardOnDrag: Boolean = false,
+    val useFakeTime:  Boolean = false,
 )
 
 val LocalFlags = compositionLocalOf<Flags> {
     error("LocalFlags must be part of the call hierarchy to provide configuration")
 }
+
+fun isProd() = URLs.API_ENDPOINT == URLs.PRODUCTION_URL

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/Flags.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/Flags.kt
@@ -6,6 +6,7 @@ data class Flags(
     val enableBackOnMainScreens: Boolean = true,
     val supportsNotifications: Boolean = true,
     val rippleEnabled: Boolean = true,
+    val redirectFeedbackToSessionPage: Boolean = false,
 )
 
 val LocalFlags = compositionLocalOf<Flags> {

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/FlagsManager.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/FlagsManager.kt
@@ -1,0 +1,43 @@
+package org.jetbrains.kotlinconf
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.jetbrains.kotlinconf.storage.ApplicationStorage
+
+class FlagsManager(
+    private val platformFlags: Flags,
+    private val storage: ApplicationStorage,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    val flags = storage.getFlags()
+        .map { it ?: platformFlags }
+        .stateIn(scope, SharingStarted.Eagerly, platformFlags)
+
+    init {
+        scope.launch {
+            val storedFlags = storage.getFlags().first()
+            if (storedFlags == null) {
+                storage.setFlags(platformFlags)
+            }
+        }
+    }
+
+    fun resetFlags() {
+        scope.launch {
+            storage.setFlags(platformFlags)
+        }
+    }
+
+    fun updateFlags(newFlags: Flags) {
+        scope.launch {
+            storage.setFlags(newFlags)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/HideKeyboardOnDragHandler.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/HideKeyboardOnDragHandler.kt
@@ -1,0 +1,24 @@
+package org.jetbrains.kotlinconf
+
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
+
+@Composable
+fun HideKeyboardOnDragHandler(listState: LazyListState) {
+    if (LocalFlags.current.hideKeyboardOnDrag) {
+        val keyboard = LocalSoftwareKeyboardController.current
+        LaunchedEffect(listState) {
+            listState.interactionSource.interactions
+                .distinctUntilChanged()
+                .filterIsInstance<DragInteraction>()
+                .map { dragInteraction -> dragInteraction is DragInteraction.Start }
+                .collect { keyboard?.hide() }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/Model.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/Model.kt
@@ -42,7 +42,8 @@ class Session(
     val location: String,
     val startsAt: LocalDateTime,
     val endsAt: LocalDateTime,
-    val tags: List<String>? = null
+    val tags: List<String>? = null,
+    val videoUrl: String? = null,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
@@ -20,6 +20,7 @@ data class SessionCardView(
     val description: String,
     val tags: List<String>,
     val startsInMinutes: Int?,
+    val videoUrl: String?,
 ) {
     val fullTimeline: String = DateTimeFormatting.dateAndTime(startsAt)
     val shortTimeline: String = DateTimeFormatting.timeToTime(startsAt, endsAt)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/TimeProvider.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/TimeProvider.kt
@@ -62,7 +62,7 @@ class ServerBasedTimeProvider(private val client: APIClient) : TimeProvider {
 
 class FakeTimeProvider(
     private val logger: Logger,
-    baseTime: LocalDateTime = LocalDateTime.parse("2025-05-22T14:37:00"),
+    baseTime: LocalDateTime = LocalDateTime.parse("2025-05-22T14:30:00"),
     private val freezeTime: Boolean = false,
     private val speedMultiplier: Double = 20.0,
 ) : TimeProvider {

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
@@ -93,7 +93,8 @@ fun Session.asSessionCard(
         tags = tags ?: emptyList(),
         startsInMinutes = (startsAt - now).inWholeMinutes.toInt().let { diff ->
             if (diff in 1..30) diff else null
-        }
+        },
+        videoUrl = videoUrl,
     )
 }
 

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/KotlinConfNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/KotlinConfNavHost.kt
@@ -205,12 +205,14 @@ fun NavGraphBuilder.screens(navController: NavHostController) {
     }
     composable<SessionScreen>(typeMap = mapOf(typeOf<SessionId>() to SessionIdNavType)) {
         val params = it.toRoute<SessionScreen>()
+        val urlHandler = LocalUriHandler.current
         SessionScreen(
             sessionId = params.sessionId,
             openedForFeedback = params.openedForFeedback,
             onBack = navController::navigateUp,
             onPrivacyPolicyNeeded = { navController.navigate(PrivacyPolicyScreen) },
             onSpeaker = { speakerId -> navController.navigate(SpeakerDetailScreen(speakerId)) },
+            onWatchVideo = { videoUrl -> urlHandler.openUri(videoUrl) },
             onNavigateToMap = { roomName ->
                 navController.navigate(NestedMapScreen(roomName))
             },

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/KotlinConfNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/KotlinConfNavHost.kt
@@ -199,8 +199,10 @@ fun NavGraphBuilder.screens(navController: NavHostController) {
         )
     }
     composable<SessionScreen>(typeMap = mapOf(typeOf<SessionId>() to SessionIdNavType)) {
+        val params = it.toRoute<SessionScreen>()
         SessionScreen(
-            sessionId = it.toRoute<SessionScreen>().sessionId,
+            sessionId = params.sessionId,
+            openedForFeedback = params.openedForFeedback,
             onBack = navController::navigateUp,
             onPrivacyPolicyNeeded = { navController.navigate(PrivacyPolicyScreen) },
             onSpeaker = { speakerId -> navController.navigate(SpeakerDetailScreen(speakerId)) },

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/KotlinConfNavHost.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/KotlinConfNavHost.kt
@@ -17,17 +17,21 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
 import androidx.navigation.toRoute
 import kotlinx.coroutines.channels.Channel
+import org.jetbrains.kotlinconf.FlagsManager
 import org.jetbrains.kotlinconf.LocalFlags
 import org.jetbrains.kotlinconf.LocalNotificationId
 import org.jetbrains.kotlinconf.PartnerId
 import org.jetbrains.kotlinconf.SessionId
 import org.jetbrains.kotlinconf.SpeakerId
 import org.jetbrains.kotlinconf.URLs
+import org.jetbrains.kotlinconf.isProd
+import org.koin.compose.koinInject
 import org.jetbrains.kotlinconf.screens.AboutAppScreen
 import org.jetbrains.kotlinconf.screens.AboutConference
 import org.jetbrains.kotlinconf.screens.AppPrivacyPolicy
 import org.jetbrains.kotlinconf.screens.AppTermsOfUse
 import org.jetbrains.kotlinconf.screens.CodeOfConduct
+import org.jetbrains.kotlinconf.screens.DeveloperMenuScreen
 import org.jetbrains.kotlinconf.screens.LicensesScreen
 import org.jetbrains.kotlinconf.screens.MainScreen
 import org.jetbrains.kotlinconf.screens.NestedMapScreen
@@ -138,6 +142,7 @@ fun NavGraphBuilder.screens(navController: NavHostController) {
             onPrivacyPolicy = { navController.navigate(AppPrivacyPolicyScreen) },
             onTermsOfUse = { navController.navigate(AppTermsOfUseScreen) },
             onLicenses = { navController.navigate(LicensesScreen) },
+            onDeveloperMenu = { navController.navigate(DeveloperMenuScreen) },
         )
     }
     composable<LicensesScreen> {
@@ -228,6 +233,12 @@ fun NavGraphBuilder.screens(navController: NavHostController) {
     composable<NewsDetailScreen> {
         val newsId = it.toRoute<NewsDetailScreen>().newsId
         NewsDetailScreen(newsId, onBack = navController::navigateUp)
+    }
+
+    if (!isProd()) {
+        composable<DeveloperMenuScreen> {
+            DeveloperMenuScreen(onBack = navController::navigateUp)
+        }
     }
 
     composable<NestedMapScreen> {

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/Routes.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/Routes.kt
@@ -115,3 +115,7 @@ data object NewsListScreen
 @Serializable
 @SerialName("News")
 data class NewsDetailScreen(val newsId: String)
+
+@Serializable
+@SerialName("DeveloperMenu")
+data object DeveloperMenuScreen

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/Routes.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/Routes.kt
@@ -64,7 +64,10 @@ data object LicensesScreen
 
 @Serializable
 @SerialName("License")
-data class SingleLicenseScreen(val licenseName: String, val licenseText: String)
+data class SingleLicenseScreen(
+    val licenseName: String,
+    val licenseText: String,
+)
 
 @Serializable
 @SerialName("Partners")
@@ -84,7 +87,10 @@ data object ScheduleScreen
 
 @Serializable
 @SerialName("Session")
-data class SessionScreen(val sessionId: SessionId)
+data class SessionScreen(
+    val sessionId: SessionId,
+    val openedForFeedback: Boolean = false,
+)
 
 @Serializable
 @SerialName("Speakers")

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AboutAppScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AboutAppScreen.kt
@@ -60,7 +60,7 @@ fun AboutAppScreen(
 
             PageMenuItem(
                 stringResource(Res.string.about_app_link_github),
-                drawableResource = Res.drawable.arrow_up_right_24,
+                drawableEnd = Res.drawable.arrow_up_right_24,
                 onClick = onGitHubRepo,
             )
 
@@ -68,7 +68,7 @@ fun AboutAppScreen(
             if (storeUrlAvailable) {
                 PageMenuItem(
                     stringResource(Res.string.about_app_link_rate),
-                    drawableResource = Res.drawable.arrow_up_right_24,
+                    drawableEnd = Res.drawable.arrow_up_right_24,
                     onClick = onRateApp,
                 )
             }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AboutAppScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AboutAppScreen.kt
@@ -7,7 +7,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -27,6 +30,7 @@ import kotlinconfapp.shared.generated.resources.app_version
 import kotlinconfapp.shared.generated.resources.arrow_up_right_24
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.ScreenWithTitle
+import org.jetbrains.kotlinconf.isProd
 import org.jetbrains.kotlinconf.ui.components.PageMenuItem
 import org.jetbrains.kotlinconf.ui.components.StyledText
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
@@ -41,6 +45,7 @@ fun AboutAppScreen(
     onPrivacyPolicy: () -> Unit,
     onTermsOfUse: () -> Unit,
     onLicenses: () -> Unit,
+    onDeveloperMenu: () -> Unit = {},
 ) {
     ScreenWithTitle(
         title = stringResource(Res.string.about_app_title),
@@ -75,6 +80,7 @@ fun AboutAppScreen(
 
             val clipboardManager = LocalClipboardManager.current
             val appVersion = stringResource(resource = Res.string.app_version)
+            var tapCount by remember { mutableStateOf(0) }
             StyledText(
                 text = appVersion,
                 style = KotlinConfTheme.typography.text2,
@@ -82,7 +88,17 @@ fun AboutAppScreen(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .clip(RoundedCornerShape(8.dp))
-                    .clickable { clipboardManager.setText(AnnotatedString(appVersion)) }
+                    .clickable { 
+                        clipboardManager.setText(AnnotatedString(appVersion))
+
+                        if (!isProd()) {
+                            tapCount++
+                            if (tapCount >= 5) {
+                                tapCount = 0
+                                onDeveloperMenu()
+                            }
+                        }
+                    }
                     .padding(16.dp)
             )
         }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AboutConference.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AboutConference.kt
@@ -113,7 +113,7 @@ fun AboutConference(
             )
             PageMenuItem(
                 label = stringResource(Res.string.about_conference_website_link),
-                drawableResource = Res.drawable.arrow_up_right_24,
+                drawableEnd = Res.drawable.arrow_up_right_24,
                 onClick = onWebsiteLink,
             )
         }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/DeveloperMenuScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/DeveloperMenuScreen.kt
@@ -1,0 +1,136 @@
+package org.jetbrains.kotlinconf.screens
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinconfapp.ui_components.generated.resources.Res
+import kotlinconfapp.ui_components.generated.resources.arrow_left_24
+import kotlinconfapp.ui_components.generated.resources.main_header_back
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.kotlinconf.FlagsManager
+import org.jetbrains.kotlinconf.LocalFlags
+import org.jetbrains.kotlinconf.ui.components.Button
+import org.jetbrains.kotlinconf.ui.components.Divider
+import org.jetbrains.kotlinconf.ui.components.MainHeaderTitleBar
+import org.jetbrains.kotlinconf.ui.components.SettingsItem
+import org.jetbrains.kotlinconf.ui.components.TopMenuButton
+import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
+import org.jetbrains.kotlinconf.utils.bottomInsetPadding
+import org.jetbrains.kotlinconf.utils.plus
+import org.jetbrains.kotlinconf.utils.topInsetPadding
+import org.koin.compose.koinInject
+
+@Composable
+fun DeveloperMenuScreen(
+    onBack: () -> Unit,
+) {
+    val flags = LocalFlags.current
+    val flagsManager = koinInject<FlagsManager>()
+
+    val contentScrollState: ScrollState = rememberScrollState()
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(color = KotlinConfTheme.colors.mainBackground)
+            .padding(topInsetPadding() + bottomInsetPadding())
+    ) {
+        MainHeaderTitleBar(
+            title = "Developer Menu",
+            startContent = {
+                TopMenuButton(
+                    icon = Res.drawable.arrow_left_24,
+                    contentDescription = stringResource(Res.string.main_header_back),
+                    onClick = onBack,
+                )
+            }
+        )
+
+        Divider(thickness = 1.dp, color = KotlinConfTheme.colors.strokePale)
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier
+                .verticalScroll(contentScrollState)
+                .padding(12.dp)
+                .weight(1f)
+        ) {
+            SettingsItem(
+                title = "Enable back on main screens",
+                note = "Allow users to use back navigation between the top-level destinations on the Main screen",
+                enabled = flags.enableBackOnMainScreens,
+                onToggle = {
+                    flagsManager.updateFlags(flags.copy(enableBackOnMainScreens = it))
+                }
+            )
+
+            SettingsItem(
+                title = "Supports notifications",
+                note = "Whether this device should display notification settings",
+                enabled = flags.supportsNotifications,
+                onToggle = {
+                    flagsManager.updateFlags(flags.copy(supportsNotifications = it))
+                }
+            )
+
+            SettingsItem(
+                title = "Ripple enabled",
+                note = "Show ripple animations on tapped elements",
+                enabled = flags.rippleEnabled,
+                onToggle = {
+                    flagsManager.updateFlags(flags.copy(rippleEnabled = it))
+                }
+            )
+
+            SettingsItem(
+                title = "Redirect feedback to session page",
+                note = "Don't allow typing in detailed feedback on the schedule screen, redirect to the session screen for written responses instead",
+                enabled = flags.redirectFeedbackToSessionPage,
+                onToggle = {
+                    flagsManager.updateFlags(flags.copy(redirectFeedbackToSessionPage = it))
+                }
+            )
+
+            SettingsItem(
+                title = "Hide keyboard on drag",
+                note = "Hides the keyboard when the content is scrolled",
+                enabled = flags.hideKeyboardOnDrag,
+                onToggle = {
+                    flagsManager.updateFlags(flags.copy(hideKeyboardOnDrag = it))
+                }
+            )
+
+            SettingsItem(
+                title = "Use fake time (requires app restart)",
+                note = "Simulate a date and time in the middle of the conference. Useful for testing voting and feedback features which are only available for sessions that already started. Fake time passes at 20x speed, so you'll see how the schedule changes and receive reminder notifications much quicker. Fake time restarts from the same point on every app start.",
+                enabled = flags.useFakeTime,
+                onToggle = {
+                    flagsManager.updateFlags(flags.copy(useFakeTime = it))
+                }
+            )
+        }
+
+        Divider(thickness = 1.dp, color = KotlinConfTheme.colors.strokePale)
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxWidth().padding(16.dp)
+        ) {
+            Button(
+                label = "Reset to Platform Defaults",
+                onClick = { flagsManager.resetFlags() },
+                modifier = Modifier.fillMaxWidth(),
+                primary = true
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/MainScreen.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.kotlinconf.screens
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Column
@@ -13,8 +15,6 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -127,15 +127,14 @@ fun MainScreen(
             }
         }
 
-        val keyboardVisible by keyboardAsState()
-        if (!keyboardVisible) {
+        AnimatedVisibility(!isKeyboardOpen(), enter = fadeIn(snap()), exit = fadeOut(snap())) {
             BottomNavigation(nestedNavController)
         }
     }
 }
 
 @Composable
-fun MainBackHandler() {
+private fun MainBackHandler() {
     if (!LocalFlags.current.enableBackOnMainScreens) {
         // Prevent back navigation with an empty handler
         @OptIn(ExperimentalComposeUiApi::class)
@@ -144,9 +143,9 @@ fun MainBackHandler() {
 }
 
 @Composable
-private fun keyboardAsState(): State<Boolean> {
-    val isImeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
-    return rememberUpdatedState(isImeVisible)
+private fun isKeyboardOpen(): Boolean {
+    val bottomInset = WindowInsets.ime.getBottom(LocalDensity.current)
+    return rememberUpdatedState(bottomInset > 300).value
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/MainScreen.kt
@@ -116,6 +116,9 @@ fun MainScreen(
                 ScheduleScreen(
                     onSession = { rootNavController.navigate(SessionScreen(it)) },
                     onPrivacyPolicyNeeded = { rootNavController.navigate(PrivacyPolicyScreen) },
+                    onRequestFeedbackWithComment = { sessionId ->
+                        rootNavController.navigate(SessionScreen(sessionId, openedForFeedback = true))
+                    },
                 )
             }
             composable<MapScreen> {
@@ -136,7 +139,7 @@ fun MainBackHandler() {
     if (!LocalFlags.current.enableBackOnMainScreens) {
         // Prevent back navigation with an empty handler
         @OptIn(ExperimentalComposeUiApi::class)
-        BackHandler(true) {  }
+        BackHandler(true) { }
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -50,6 +50,7 @@ import kotlinconfapp.ui_components.generated.resources.search_24
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.DayValues
+import org.jetbrains.kotlinconf.LocalFlags
 import org.jetbrains.kotlinconf.ScrollToTopHandler
 import org.jetbrains.kotlinconf.SessionCardView
 import org.jetbrains.kotlinconf.SessionId
@@ -87,6 +88,7 @@ import kotlinconfapp.ui_components.generated.resources.Res as UiRes
 fun ScheduleScreen(
     onSession: (SessionId) -> Unit,
     onPrivacyPolicyNeeded: () -> Unit,
+    onRequestFeedbackWithComment: (SessionId) -> Unit,
     viewModel: ScheduleViewModel = koinViewModel(),
 ) {
     val scope = rememberCoroutineScope()
@@ -245,6 +247,11 @@ fun ScheduleScreen(
                                     onSubmitFeedbackWithComment = { sessionId, emotion, comment ->
                                         viewModel.onSubmitFeedbackWithComment(sessionId, emotion, comment)
                                     },
+                                    onRequestFeedbackWithComment = if (LocalFlags.current.redirectFeedbackToSessionPage) {
+                                        onRequestFeedbackWithComment
+                                    } else {
+                                        null
+                                    },
                                     onBookmark = { sessionId, isBookmarked ->
                                         viewModel.onBookmark(sessionId, isBookmarked)
                                     },
@@ -381,7 +388,7 @@ private fun Header(
 }
 
 @Composable
-fun ScheduleList(
+private fun ScheduleList(
     scheduleItems: List<ScheduleListItem>,
     onSession: (SessionId) -> Unit,
     listState: LazyListState,
@@ -389,6 +396,7 @@ fun ScheduleList(
     userSignedIn: Boolean,
     onSubmitFeedback: (SessionId, Emotion?) -> Unit,
     onSubmitFeedbackWithComment: (SessionId, Emotion, String) -> Unit,
+    onRequestFeedbackWithComment: ((SessionId) -> Unit)?,
     onBookmark: (SessionId, Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -448,6 +456,7 @@ fun ScheduleList(
                                     onBookmark = onBookmark,
                                     onSubmitFeedback = onSubmitFeedback,
                                     onSubmitFeedbackWithComment = onSubmitFeedbackWithComment,
+                                    onRequestFeedbackWithComment = onRequestFeedbackWithComment,
                                     onSession = onSession,
                                     modifier = Modifier
                                         .padding(horizontal = 32.dp)
@@ -471,6 +480,7 @@ fun ScheduleList(
                                         onBookmark = onBookmark,
                                         onSubmitFeedback = onSubmitFeedback,
                                         onSubmitFeedbackWithComment = onSubmitFeedbackWithComment,
+                                        onRequestFeedbackWithComment = onRequestFeedbackWithComment,
                                         onSession = onSession,
                                         modifier = Modifier
                                             .padding(horizontal = 8.dp, vertical = 8.dp)
@@ -498,6 +508,7 @@ fun ScheduleList(
                             onBookmark = onBookmark,
                             onSubmitFeedback = onSubmitFeedback,
                             onSubmitFeedbackWithComment = onSubmitFeedbackWithComment,
+                            onRequestFeedbackWithComment = onRequestFeedbackWithComment,
                             onSession = onSession,
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -554,6 +565,7 @@ private fun SessionCard(
     session: SessionCardView,
     onBookmark: (SessionId, Boolean) -> Unit,
     onSubmitFeedback: (SessionId, Emotion?) -> Unit,
+    onRequestFeedbackWithComment: ((SessionId) -> Unit)?,
     onSubmitFeedbackWithComment: (SessionId, Emotion, String) -> Unit,
     onSession: (SessionId) -> Unit,
     feedbackEnabled: Boolean,
@@ -586,6 +598,11 @@ private fun SessionCard(
         initialEmotion = session.vote?.toEmotion(),
         onSubmitFeedback = { emotion ->
             onSubmitFeedback(session.id, emotion)
+        },
+        onRequestFeedbackWithComment = if (onRequestFeedbackWithComment != null) {
+            { onRequestFeedbackWithComment(session.id) }
+        } else {
+            null
         },
         onSubmitFeedbackWithComment = { emotion, comment ->
             onSubmitFeedbackWithComment(session.id, emotion, comment)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -50,6 +50,7 @@ import kotlinconfapp.ui_components.generated.resources.search_24
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.DayValues
+import org.jetbrains.kotlinconf.HideKeyboardOnDragHandler
 import org.jetbrains.kotlinconf.LocalFlags
 import org.jetbrains.kotlinconf.ScrollToTopHandler
 import org.jetbrains.kotlinconf.SessionCardView
@@ -401,6 +402,8 @@ private fun ScheduleList(
     modifier: Modifier = Modifier,
 ) {
     ScrollToTopHandler(listState)
+    HideKeyboardOnDragHandler(listState)
+
     LazyColumn(
         state = listState,
         modifier = modifier,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -610,10 +610,8 @@ private fun SessionCard(
         onSubmitFeedback = { emotion ->
             onSubmitFeedback(session.id, emotion)
         },
-        onRequestFeedbackWithComment = if (onRequestFeedbackWithComment != null) {
+        onRequestFeedbackWithComment = onRequestFeedbackWithComment?.let {
             { onRequestFeedbackWithComment(session.id) }
-        } else {
-            null
         },
         onSubmitFeedbackWithComment = { emotion, comment ->
             onSubmitFeedbackWithComment(session.id, emotion, comment)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -256,7 +256,7 @@ fun ScheduleScreen(
                                     onBookmark = { sessionId, isBookmarked ->
                                         viewModel.onBookmark(sessionId, isBookmarked)
                                     },
-                                    modifier = Modifier.fillMaxSize()
+                                    modifier = Modifier.fillMaxSize().clipToBounds()
                                 )
                             } else {
                                 MinorError(

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -56,7 +56,9 @@ import org.jetbrains.kotlinconf.ScrollToTopHandler
 import org.jetbrains.kotlinconf.SessionCardView
 import org.jetbrains.kotlinconf.SessionId
 import org.jetbrains.kotlinconf.SessionState
+import org.jetbrains.kotlinconf.TimeProvider
 import org.jetbrains.kotlinconf.isLive
+import org.jetbrains.kotlinconf.isProd
 import org.jetbrains.kotlinconf.toEmotion
 import org.jetbrains.kotlinconf.ui.components.DayHeader
 import org.jetbrains.kotlinconf.ui.components.Divider
@@ -82,6 +84,7 @@ import org.jetbrains.kotlinconf.ui.components.TopMenuButton
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
 import org.jetbrains.kotlinconf.utils.DateTimeFormatting
 import org.jetbrains.kotlinconf.utils.FadingAnimationSpec
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import kotlinconfapp.ui_components.generated.resources.Res as UiRes
 
@@ -347,7 +350,12 @@ private fun Header(
         state = headerState,
         titleContent = {
             MainHeaderTitleBar(
-                title = stringResource(Res.string.nav_destination_schedule),
+                title = if (!isProd() && LocalFlags.current.useFakeTime) {
+                    val dateTime by koinInject<TimeProvider>().time.collectAsStateWithLifecycle()
+                    "Fake time: ${DateTimeFormatting.dateAndTime(dateTime)}"
+                } else {
+                    stringResource(Res.string.nav_destination_schedule)
+                },
                 startContent = startContent,
                 endContent = {
                     TopMenuButton(

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
@@ -43,10 +43,13 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.shared.generated.resources.Res
 import kotlinconfapp.shared.generated.resources.arrow_left_24
+import kotlinconfapp.shared.generated.resources.arrow_up_right_24
 import kotlinconfapp.shared.generated.resources.down_24
 import kotlinconfapp.shared.generated.resources.navigate_back
+import kotlinconfapp.shared.generated.resources.play_video
 import kotlinconfapp.shared.generated.resources.session_screen_error
 import kotlinconfapp.shared.generated.resources.session_title
+import kotlinconfapp.shared.generated.resources.session_watch_video
 import kotlinconfapp.shared.generated.resources.session_your_feedback
 import kotlinconfapp.shared.generated.resources.up_24
 import kotlinconfapp.ui_components.generated.resources.talk_card_how_was_the_talk
@@ -67,6 +70,7 @@ import org.jetbrains.kotlinconf.ui.components.FeedbackForm
 import org.jetbrains.kotlinconf.ui.components.KodeeIconLarge
 import org.jetbrains.kotlinconf.ui.components.MainHeaderTitleBar
 import org.jetbrains.kotlinconf.ui.components.MajorError
+import org.jetbrains.kotlinconf.ui.components.PageMenuItem
 import org.jetbrains.kotlinconf.ui.components.PageTitle
 import org.jetbrains.kotlinconf.ui.components.SpeakerCard
 import org.jetbrains.kotlinconf.ui.components.StyledText
@@ -88,6 +92,7 @@ fun SessionScreen(
     onSpeaker: (SpeakerId) -> Unit,
     onPrivacyPolicyNeeded: () -> Unit,
     onNavigateToMap: (String) -> Unit,
+    onWatchVideo: (String) -> Unit,
     viewModel: SessionViewModel = koinViewModel { parametersOf(sessionId) }
 ) {
     val session = viewModel.session.collectAsState().value
@@ -147,15 +152,26 @@ fun SessionScreen(
                     contentPadding = bottomInsetPadding()
                 ) {
                     item {
-                        PageTitle(
-                            time = session.fullTimeline,
-                            title = session.title,
-                            lightning = session.isLightning,
-                            tags = session.tags,
-                            bookmarked = session.isFavorite,
-                            onBookmark = { viewModel.toggleFavorite(it) },
-                            modifier = Modifier.padding(vertical = 24.dp),
-                        )
+                        Column {
+                            PageTitle(
+                                time = session.fullTimeline,
+                                title = session.title,
+                                lightning = session.isLightning,
+                                tags = session.tags,
+                                bookmarked = session.isFavorite,
+                                onBookmark = { viewModel.toggleFavorite(it) },
+                                modifier = Modifier.padding(vertical = 24.dp),
+                            )
+                            if (session.videoUrl != null) {
+                                PageMenuItem(
+                                    label = stringResource(Res.string.session_watch_video),
+                                    onClick = { onWatchVideo(session.videoUrl) },
+                                    drawableStart = Res.drawable.play_video,
+                                    drawableEnd = Res.drawable.arrow_up_right_24,
+                                    modifier = Modifier.padding(bottom = 12.dp),
+                                )
+                            }
+                        }
                     }
 
                     item {

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakerDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakerDetailScreen.kt
@@ -147,6 +147,7 @@ fun SpeakerDetailScreen(
                             userSignedIn = false, // Feedback not enabled on this screen
                             onSubmitFeedback = { }, // Feedback not enabled on this screen
                             onSubmitFeedbackWithComment = { _, _ -> }, // Feedback not enabled on this screen
+                            onRequestFeedbackWithComment = null, // Feedback not enabled on this screen
                             onClick = { onSession(session.id) },
                             modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
                         )

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakerDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakerDetailScreen.kt
@@ -23,6 +23,7 @@ import kotlinconfapp.shared.generated.resources.speaker_detail_title
 import kotlinconfapp.ui_components.generated.resources.arrow_left_24
 import kotlinconfapp.ui_components.generated.resources.main_header_back
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.kotlinconf.ScrollToTopHandler
 import org.jetbrains.kotlinconf.SessionId
 import org.jetbrains.kotlinconf.SpeakerId
 import org.jetbrains.kotlinconf.toEmotion
@@ -81,11 +82,13 @@ fun SpeakerDetailScreen(
                     modifier = Modifier.fillMaxSize(),
                 )
             } else {
+                val scrollState = rememberScrollState()
+                ScrollToTopHandler(scrollState)
                 Column(
                     modifier = Modifier
                         .padding(vertical = 16.dp, horizontal = 12.dp)
                         .padding(bottomInsetPadding())
-                        .verticalScroll(rememberScrollState()),
+                        .verticalScroll(scrollState),
                 ) {
                     StyledText(
                         text = currentSpeaker.name,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakersScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakersScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -20,7 +19,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.shared.generated.resources.Res
@@ -30,6 +28,7 @@ import kotlinconfapp.shared.generated.resources.speakers_title
 import kotlinconfapp.ui_components.generated.resources.main_header_search_hint
 import kotlinconfapp.ui_components.generated.resources.search_24
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.kotlinconf.HideKeyboardOnDragHandler
 import org.jetbrains.kotlinconf.ScrollToTopHandler
 import org.jetbrains.kotlinconf.SpeakerId
 import org.jetbrains.kotlinconf.ui.components.Divider
@@ -111,6 +110,7 @@ fun SpeakersScreen(
                 is SpeakersUiState.Content -> {
                     val listState = rememberLazyListState()
                     ScrollToTopHandler(listState)
+                    HideKeyboardOnDragHandler(listState)
                     LazyColumn(
                         state = listState,
                         modifier = Modifier.fillMaxSize(),

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/storage/ApplicationStorage.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/storage/ApplicationStorage.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlinconf.storage
 
 import kotlinx.coroutines.flow.Flow
 import org.jetbrains.kotlinconf.Conference
+import org.jetbrains.kotlinconf.Flags
 import org.jetbrains.kotlinconf.NewsItem
 import org.jetbrains.kotlinconf.NotificationSettings
 import org.jetbrains.kotlinconf.SessionId
@@ -35,6 +36,10 @@ interface ApplicationStorage {
 
     fun getVotes(): Flow<List<VoteInfo>>
     suspend fun setVotes(value: List<VoteInfo>)
+
+    fun getFlagsBlocking(): Flags?
+    fun getFlags(): Flow<Flags?>
+    suspend fun setFlags(value: Flags)
 
     fun ensureCurrentVersion()
 }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/storage/MultiplatformSettingsStorage.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/storage/MultiplatformSettingsStorage.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
 import org.jetbrains.kotlinconf.Conference
+import org.jetbrains.kotlinconf.Flags
 import org.jetbrains.kotlinconf.NewsItem
 import org.jetbrains.kotlinconf.NotificationSettings
 import org.jetbrains.kotlinconf.SessionId
@@ -19,6 +20,10 @@ import org.jetbrains.kotlinconf.VoteInfo
 class MultiplatformSettingsStorage(
     private val settings: ObservableSettings
 ) : ApplicationStorage {
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
     override fun getUserId(): Flow<String?> = settings.getStringOrNullFlow(Keys.USER_ID)
     override suspend fun setUserId(value: String?) = settings.set(Keys.USER_ID, value)
 
@@ -35,35 +40,44 @@ class MultiplatformSettingsStorage(
         .set(Keys.THEME, value.name)
 
     override fun getConferenceCache(): Flow<Conference?> = settings.getStringOrNullFlow(Keys.CONFERENCE_CACHE)
-        .map { it?.let { Json.decodeFromString<Conference>(it) } }
+        .map { it?.let { json.decodeFromString<Conference>(it) } }
 
     override suspend fun setConferenceCache(value: Conference) = settings
-        .set(Keys.CONFERENCE_CACHE, Json.encodeToString(value))
+        .set(Keys.CONFERENCE_CACHE, json.encodeToString(value))
 
     override fun getFavorites(): Flow<Set<SessionId>> = settings.getStringOrNullFlow(Keys.FAVORITES)
-        .map { it?.let { Json.decodeFromString<Set<SessionId>>(it) } ?: emptySet() }
+        .map { it?.let { json.decodeFromString<Set<SessionId>>(it) } ?: emptySet() }
 
     override suspend fun setFavorites(value: Set<SessionId>) = settings
-        .set(Keys.FAVORITES, Json.encodeToString(value))
+        .set(Keys.FAVORITES, json.encodeToString(value))
 
     override fun getNews(): Flow<List<NewsItem>> = settings.getStringOrNullFlow(Keys.NEWS_CACHE)
-        .map { it?.let { Json.decodeFromString<List<NewsItem>>(it) } ?: emptyList() }
+        .map { it?.let { json.decodeFromString<List<NewsItem>>(it) } ?: emptyList() }
 
     override suspend fun setNews(value: List<NewsItem>) = settings
-        .set(Keys.NEWS_CACHE, Json.encodeToString(value))
+        .set(Keys.NEWS_CACHE, json.encodeToString(value))
 
     override fun getNotificationSettings(): Flow<NotificationSettings?> =
         settings.getStringOrNullFlow(Keys.NOTIFICATION_SETTINGS)
-            .map { it?.let { Json.decodeFromString<NotificationSettings>(it) } }
+            .map { it?.let { json.decodeFromString<NotificationSettings>(it) } }
 
     override suspend fun setNotificationSettings(value: NotificationSettings) = settings
-        .set(Keys.NOTIFICATION_SETTINGS, Json.encodeToString(value))
+        .set(Keys.NOTIFICATION_SETTINGS, json.encodeToString(value))
 
     override fun getVotes(): Flow<List<VoteInfo>> = settings.getStringOrNullFlow(Keys.VOTES)
-        .map { it?.let { Json.decodeFromString<List<VoteInfo>>(it) } ?: emptyList() }
+        .map { it?.let { json.decodeFromString<List<VoteInfo>>(it) } ?: emptyList() }
 
     override suspend fun setVotes(value: List<VoteInfo>) = settings
-        .set(Keys.VOTES, Json.encodeToString(value))
+        .set(Keys.VOTES, json.encodeToString(value))
+
+    override fun getFlagsBlocking(): Flags? =
+        settings.getStringOrNull(Keys.FLAGS)?.let { json.decodeFromString<Flags>(it) }
+
+    override fun getFlags(): Flow<Flags?> = settings.getStringOrNullFlow(Keys.FLAGS)
+        .map { it?.let { json.decodeFromString<Flags>(it) } }
+
+    override suspend fun setFlags(value: Flags) = settings
+        .set(Keys.FLAGS, json.encodeToString(value))
 
     override fun ensureCurrentVersion() {
         val version = settings.getInt(Keys.STORAGE_VERSION, 0)
@@ -89,5 +103,6 @@ class MultiplatformSettingsStorage(
         const val FAVORITES = "favorites"
         const val NOTIFICATION_SETTINGS = "notificationSettings"
         const val VOTES = "votes"
+        const val FLAGS = "flags"
     }
 }

--- a/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/main.ios.kt
+++ b/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/main.ios.kt
@@ -32,6 +32,7 @@ fun initApp() = initApp(
     flags = Flags(
         enableBackOnMainScreens = false,
         rippleEnabled = false,
+        redirectFeedbackToSessionPage = true,
     )
 )
 

--- a/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/main.ios.kt
+++ b/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/main.ios.kt
@@ -32,7 +32,7 @@ fun initApp() = initApp(
     flags = Flags(
         enableBackOnMainScreens = false,
         rippleEnabled = false,
-        redirectFeedbackToSessionPage = true,
+        hideKeyboardOnDrag = true,
     )
 )
 

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Action.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Action.kt
@@ -33,9 +33,9 @@ fun Action(
     label: String,
     icon: DrawableResource,
     size: ActionSize,
-    enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     iconRotation: Float = 0f,
 ) {
     val color by animateColorAsState(

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -210,7 +211,8 @@ internal fun FiltersPreview() {
             toggleItem = { item, value ->
                 val newItem = item.copy(isSelected = value)
                 tags.replace(item, newItem)
-            }
+            },
+            modifier = Modifier.height(300.dp),
         )
     }
 }

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/PageMenuItem.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/PageMenuItem.kt
@@ -1,9 +1,10 @@
 package org.jetbrains.kotlinconf.ui.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -18,6 +19,7 @@ import kotlinconfapp.ui_components.generated.resources.Res
 import kotlinconfapp.ui_components.generated.resources.arrow_right_24
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
 import org.jetbrains.kotlinconf.ui.theme.PreviewHelper
@@ -29,7 +31,8 @@ fun PageMenuItem(
     label: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    drawableResource: DrawableResource = Res.drawable.arrow_right_24,
+    drawableStart: DrawableResource? = null,
+    drawableEnd: DrawableResource = Res.drawable.arrow_right_24,
 ) {
     Row(
         modifier
@@ -39,17 +42,22 @@ fun PageMenuItem(
             .background(KotlinConfTheme.colors.tileBackground)
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
+        if (drawableStart != null) {
+            Image(
+                painter = painterResource(drawableStart),
+                modifier = Modifier.padding(end = 8.dp).size(24.dp),
+                contentDescription = null,
+            )
+        }
         StyledText(
             text = label,
             style = KotlinConfTheme.typography.h3,
         )
+        Spacer(Modifier.weight(1f))
         Icon(
-            // TODO review icon sizing later, https://github.com/JetBrains/kotlinconf-app/issues/175
-            modifier = modifier
-                .size(24.dp),
-            painter = painterResource(drawableResource),
+            modifier = Modifier.size(24.dp),
+            painter = painterResource(drawableEnd),
             contentDescription = null,
             tint = KotlinConfTheme.colors.primaryText,
         )

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -38,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
@@ -416,7 +418,12 @@ private fun FeedbackBlock(
             exit = fadeOut() + shrinkVertically(clip = false, shrinkTowards = Alignment.Top),
         ) {
             val focusRequester = remember { FocusRequester() }
+            val bringIntoViewRequester = remember { BringIntoViewRequester() }
             val hapticFeedback = LocalHapticFeedback.current
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
+                bringIntoViewRequester.bringIntoView()
+            }
             FeedbackForm(
                 emotion = selectedEmotion,
                 onSubmit = { emotion, comment ->

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
@@ -421,8 +421,8 @@ private fun FeedbackBlock(
             val bringIntoViewRequester = remember { BringIntoViewRequester() }
             val hapticFeedback = LocalHapticFeedback.current
             LaunchedEffect(focusRequester) {
-                focusRequester.requestFocus()
                 bringIntoViewRequester.bringIntoView()
+                focusRequester.requestFocus()
             }
             FeedbackForm(
                 emotion = selectedEmotion,


### PR DESCRIPTION
* Fixes scrolling issues caused by the old UIScrollView two-way sync implementation
* Adds a `hideKeyboardOnDrag` flag which, with the bugfix above, should make iOS feedback on the schedule screen work nicely
* Adds a `redirectFeedbackToSessionPage` feature just in case, which replaces in-schedule feedback with navigating the user to the session detail page, to leave their feedback there instead

### Demos

Hide on drag demo:

https://github.com/user-attachments/assets/7bccfc97-c182-43b5-917b-36d83ea3ddfa

Redirect to session for feedback:

https://github.com/user-attachments/assets/4c23083b-fe56-4c7f-b56d-3bd200b5f9be


