### PR TITLE
Update session handling logic

### DIFF
--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
@@ -72,7 +72,7 @@ fun List<Session>.groupByTime(
                 startsAt = slot.startsAt,
                 endsAt = slot.endsAt,
                 state = SessionState.from(slot.startsAt, slot.endsAt, now),
-                sessions = sessions,
+                sessions = sessions.sortedBy { it.isLightning },
             )
         } else {
             null

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/View.kt
@@ -3,8 +3,6 @@ package org.jetbrains.kotlinconf
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import org.jetbrains.kotlinconf.utils.DateTimeFormatting
-import kotlin.collections.plus
-import kotlin.collections.plusAssign
 
 data class Day(
     val date: LocalDate,
@@ -19,8 +17,6 @@ data class TimeSlot(
 ) {
     val title: String = DateTimeFormatting.timeToTime(startsAt, endsAt)
 }
-
-val TimeSlot.isLive get() = state == SessionState.Live
 
 fun Conference.buildAgenda(
     favorites: Set<SessionId>,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -128,8 +128,8 @@ fun ScheduleScreen(
     var firstScrollPerformed by rememberSaveable { mutableStateOf(false) }
     if (!firstScrollPerformed) {
         LaunchedEffect(state) {
-            if (state is ScheduleUiState.Content && state.firstLiveIndex != -1) {
-                listState.scrollToItem(state.firstLiveIndex)
+            if (state is ScheduleUiState.Content && state.firstActiveIndex != -1) {
+                listState.scrollToItem(state.firstActiveIndex)
                 firstScrollPerformed = true
             }
         }
@@ -290,15 +290,15 @@ private fun NowButtonContent(state: ScheduleUiState, listState: LazyListState) {
 
     val scope = rememberCoroutineScope()
 
-    val firstLiveIndex = state.firstLiveIndex
-    val lastLiveIndex = state.lastLiveIndex
+    val firstActiveIndex = state.firstActiveIndex
+    val lastActiveIndex = state.lastActiveIndex
     var nowScrolling by remember { mutableStateOf(false) }
 
     val nowButtonState = derivedStateOf {
         when {
             nowScrolling -> NowButtonState.Current
 
-            firstLiveIndex == -1 || lastLiveIndex == -1 -> null
+            firstActiveIndex == -1 || lastActiveIndex == -1 -> null
 
             else -> {
                 val firstMostlyVisible = listState.firstVisibleItemIndex +
@@ -306,8 +306,8 @@ private fun NowButtonContent(state: ScheduleUiState, listState: LazyListState) {
                 val lastFullyVisible = listState.lastVisibleItemIndex - 1
 
                 when {
-                    lastFullyVisible < firstLiveIndex -> NowButtonState.Before
-                    firstMostlyVisible > lastLiveIndex -> NowButtonState.After
+                    lastFullyVisible < firstActiveIndex -> NowButtonState.Before
+                    firstMostlyVisible > lastActiveIndex -> NowButtonState.After
                     else -> NowButtonState.Current
                 }
             }
@@ -321,7 +321,7 @@ private fun NowButtonContent(state: ScheduleUiState, listState: LazyListState) {
                 scope.launch {
                     nowScrolling = true
                     try {
-                        listState.animateScrollToItem(firstLiveIndex)
+                        listState.animateScrollToItem(firstActiveIndex)
                     } finally {
                         nowScrolling = false
                     }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
@@ -233,13 +233,8 @@ class ScheduleViewModel(
                 }
 
                 if (last() is TimeSlotTitleItem) {
-                    if (isBookmarkedOnly && (allWorkshops.isNotEmpty() || allTalks.isNotEmpty())) {
-                        // If nothing was added to this slot, but there were workshops or talks,
-                        // they must have been filtered out because none of them are bookmarked
+                    if (isBookmarkedOnly) {
                         add(NoBookmarksItem(id = "empty-${timeSlot.startsAt}"))
-                    } else {
-                        // Otherwise we hide empty slots, probably service events that got grouped
-                        removeAt(lastIndex) // Don't use removeLast https://developer.android.com/about/versions/15/behavior-changes-15#openjdk-api-changes
                     }
                 }
             }


### PR DESCRIPTION
* Skips time slots with no sessions in them immediately when they're being created so we don't have to remove these later
* Improves the "Now" concept with `firstActiveIndex` / `lastActiveIndex`, making sure we point "Now" to the current live or the next upcoming session when the time is somewhere within the conference (even if that's the next day)
* Puts lightning talks at the ends of time slots