### PR TITLE
Time display fixes

### DIFF
--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/SessionCardView.kt
@@ -22,7 +22,7 @@ data class SessionCardView(
     val startsInMinutes: Int?,
     val videoUrl: String?,
 ) {
-    val fullTimeline: String = DateTimeFormatting.dateAndTime(startsAt)
+    val fullTimeline: String = DateTimeFormatting.dateAndTime(startsAt, endsAt)
     val shortTimeline: String = DateTimeFormatting.timeToTime(startsAt, endsAt)
     val isLightning: Boolean = endsAt - startsAt <= LIGHTNING_TALK_LIMIT
 }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -76,10 +76,10 @@ import org.jetbrains.kotlinconf.ui.components.ScrollIndicator
 import org.jetbrains.kotlinconf.ui.components.ServiceEvent
 import org.jetbrains.kotlinconf.ui.components.ServiceEventData
 import org.jetbrains.kotlinconf.ui.components.ServiceEvents
-import org.jetbrains.kotlinconf.ui.components.Text
 import org.jetbrains.kotlinconf.ui.components.Switcher
 import org.jetbrains.kotlinconf.ui.components.TalkCard
 import org.jetbrains.kotlinconf.ui.components.TalkStatus
+import org.jetbrains.kotlinconf.ui.components.Text
 import org.jetbrains.kotlinconf.ui.components.TopMenuButton
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
 import org.jetbrains.kotlinconf.utils.DateTimeFormatting
@@ -243,8 +243,8 @@ fun ScheduleScreen(
                                     scheduleItems = items,
                                     onSession = onSession,
                                     listState = listState,
-                                    feedbackEnabled = !isSearch,
                                     userSignedIn = targetState.userSignedIn,
+                                    isSearch = isSearch,
                                     onSubmitFeedback = { sessionId, emotion ->
                                         viewModel.onSubmitFeedback(sessionId, emotion)
                                     },
@@ -401,7 +401,7 @@ private fun ScheduleList(
     scheduleItems: List<ScheduleListItem>,
     onSession: (SessionId) -> Unit,
     listState: LazyListState,
-    feedbackEnabled: Boolean,
+    isSearch: Boolean,
     userSignedIn: Boolean,
     onSubmitFeedback: (SessionId, Emotion?) -> Unit,
     onSubmitFeedbackWithComment: (SessionId, Emotion, String) -> Unit,
@@ -462,7 +462,7 @@ private fun ScheduleList(
                             if (workshops.size == 1) {
                                 SessionCard(
                                     session = workshops[0],
-                                    feedbackEnabled = feedbackEnabled,
+                                    isSearch = isSearch,
                                     userSignedIn = userSignedIn,
                                     onBookmark = onBookmark,
                                     onSubmitFeedback = onSubmitFeedback,
@@ -486,7 +486,7 @@ private fun ScheduleList(
                                 ) { pageIndex ->
                                     SessionCard(
                                         session = workshops[pageIndex % workshops.size],
-                                        feedbackEnabled = feedbackEnabled,
+                                        isSearch = isSearch,
                                         userSignedIn = userSignedIn,
                                         onBookmark = onBookmark,
                                         onSubmitFeedback = onSubmitFeedback,
@@ -511,7 +511,7 @@ private fun ScheduleList(
                     is SessionItem -> {
                         SessionCard(
                             session = item.value,
-                            feedbackEnabled = feedbackEnabled,
+                            isSearch = isSearch,
                             userSignedIn = userSignedIn,
                             titleHighlights = item.titleHighlights,
                             tagHighlights = item.tagMatches,
@@ -579,7 +579,7 @@ private fun SessionCard(
     onRequestFeedbackWithComment: ((SessionId) -> Unit)?,
     onSubmitFeedbackWithComment: (SessionId, Emotion, String) -> Unit,
     onSession: (SessionId) -> Unit,
-    feedbackEnabled: Boolean,
+    isSearch: Boolean,
     userSignedIn: Boolean,
     modifier: Modifier = Modifier,
     titleHighlights: List<IntRange> = emptyList(),
@@ -597,7 +597,7 @@ private fun SessionCard(
         speakerHighlights = speakerHighlights,
         location = session.locationLine,
         lightning = session.isLightning,
-        time = session.shortTimeline,
+        time = if (isSearch) session.fullTimeline else session.shortTimeline,
         timeNote = session.startsInMinutes?.let { count ->
             stringResource(Res.string.schedule_in_x_minutes, count)
         },
@@ -618,7 +618,7 @@ private fun SessionCard(
         },
         onClick = { onSession(session.id) },
         modifier = modifier,
-        feedbackEnabled = feedbackEnabled && session.state != SessionState.Upcoming,
+        feedbackEnabled = !isSearch && session.state != SessionState.Upcoming,
         userSignedIn = userSignedIn,
     )
 }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/utils/DateTimeFormatting.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/utils/DateTimeFormatting.kt
@@ -42,8 +42,10 @@ object DateTimeFormatting {
 
     internal fun dateWithYear(dateTime: LocalDateTime): String = dateTime.format(dateWithYearFormat)
 
-    internal fun timeToTime(start: LocalDateTime, end: LocalDateTime): String = "${time(start)}-${time(end)}"
+    internal fun timeToTime(start: LocalDateTime, end: LocalDateTime): String = "${time(start)} – ${time(end)}"
 
     internal fun dateAndTime(dateTime: LocalDateTime): String = "${date(dateTime)}, ${time(dateTime)}"
+
+    internal fun dateAndTime(start: LocalDateTime, end: LocalDateTime): String = "${date(start)}, ${time(start)} – ${time(end)}"
 
 }

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
@@ -387,12 +387,17 @@ private fun TimeBlock(
             )
         }
 
-        Text(
-            text = time,
-            style = KotlinConfTheme.typography.text2,
-            color = textColor,
-            maxLines = 1,
-        )
+        AnimatedContent(
+            targetState = time,
+            transitionSpec = { fadeIn() togetherWith fadeOut() }
+        ) {
+            Text(
+                text = it,
+                style = KotlinConfTheme.typography.text2,
+                color = textColor,
+                maxLines = 1,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
* In talk cards, show the date for sessions on the speaker detail screen and when the schedule is being searched.
* Show the end time of sessions on the session detail screen

![image](https://github.com/user-attachments/assets/bef05cf9-d82a-46ed-938a-e013c0f38ef3)

![image](https://github.com/user-attachments/assets/e9adf371-c913-4e2d-831f-2776cf4e87be)

![image](https://github.com/user-attachments/assets/3af15758-bee9-48d0-af8d-e04c38a9fd65)
