### PR TITLE
Accessibility improvements

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -118,6 +118,8 @@ We will process your data in accordance with the App Privacy Policy. You can adj
     <string name="session_your_feedback">Your feedback</string>
     <string name="session_screen_error">The details of this session are not available at the moment.</string>
     <string name="session_watch_video">Watch the recording</string>
+    <string name="session_room_state_description_expanded">Expanded</string>
+    <string name="session_room_state_description_collapsed">Collapsed</string>
 
     <string name="map_title">Map</string>
     <string name="map_ground_floor">Ground floor</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -105,6 +105,7 @@ We will process your data in accordance with the App Privacy Policy. You can adj
     <string name="settings_theme_system">System</string>
     <string name="settings_theme_light">Light</string>
     <string name="settings_theme_dark">Dark</string>
+    <string name="settings_notifications_title">Notifications</string>
 
     <string name="schedule_action_filter_bookmarked">Filter bookmarked</string>
     <string name="schedule_action_search">Search</string>

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AboutConference.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AboutConference.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.shared.generated.resources.Res
 import kotlinconfapp.shared.generated.resources.about_conference_description
@@ -66,7 +68,11 @@ fun AboutConference(
             modifier = Modifier.padding(top = 24.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
         ) {
-            Text(text = stringResource(Res.string.about_conference_header), style = KotlinConfTheme.typography.h1)
+            Text(
+                text = stringResource(Res.string.about_conference_header),
+                style = KotlinConfTheme.typography.h1,
+                modifier = Modifier.semantics { heading() }
+            )
             Text(text = stringResource(Res.string.about_conference_description))
         }
 

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AppPrivacyPolicyPrompt.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/AppPrivacyPolicyPrompt.kt
@@ -120,7 +120,9 @@ fun AppPrivacyPolicyPrompt(
             } else {
                 Column(
                     verticalArrangement = Arrangement.spacedBy(24.dp),
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 16.dp)
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp, vertical = 16.dp)
+                        .verticalScroll(rememberScrollState())
                 ) {
                     Image(
                         imageVector = vectorResource(AppRes.drawable.kodee_privacy),

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/CodeOfConduct.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/CodeOfConduct.kt
@@ -25,7 +25,7 @@ fun CodeOfConduct(onBack: () -> Unit) {
     ) {
         Image(
             painter = painterResource(Res.drawable.kodee_code_of_conduct),
-            contentDescription = "",
+            contentDescription = null,
             modifier = Modifier.align(Alignment.CenterHorizontally).padding(bottom = 12.dp)
         )
     }

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinconfapp.shared.generated.resources.Res
@@ -443,6 +445,9 @@ private fun ScheduleList(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(top = 8.dp)
+                                .semantics {
+                                    heading()
+                                }
                         )
                     }
 

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.shared.generated.resources.Res
 import kotlinconfapp.shared.generated.resources.arrow_left_24
@@ -47,6 +49,8 @@ import kotlinconfapp.shared.generated.resources.arrow_up_right_24
 import kotlinconfapp.shared.generated.resources.down_24
 import kotlinconfapp.shared.generated.resources.navigate_back
 import kotlinconfapp.shared.generated.resources.play_video
+import kotlinconfapp.shared.generated.resources.session_room_state_description_collapsed
+import kotlinconfapp.shared.generated.resources.session_room_state_description_expanded
 import kotlinconfapp.shared.generated.resources.session_screen_error
 import kotlinconfapp.shared.generated.resources.session_title
 import kotlinconfapp.shared.generated.resources.session_watch_video
@@ -375,6 +379,12 @@ private fun RoomSection(
                 style = KotlinConfTheme.typography.h3,
             )
         } else {
+            val stateDesc = stringResource(
+                resource = if (isExpanded)
+                    Res.string.session_room_state_description_expanded
+                else
+                    Res.string.session_room_state_description_collapsed
+            )
             Action(
                 label = roomName,
                 icon = Res.drawable.down_24,
@@ -382,7 +392,11 @@ private fun RoomSection(
                 enabled = true,
                 onClick = { isExpanded = !isExpanded },
                 iconRotation = iconRotation,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        stateDescription = stateDesc
+                    }
             )
             AnimatedVisibility(
                 visible = isExpanded,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
@@ -387,10 +387,8 @@ private fun RoomSection(
             )
         } else {
             val stateDesc = stringResource(
-                resource = if (isExpanded)
-                    Res.string.session_room_state_description_expanded
-                else
-                    Res.string.session_room_state_description_collapsed
+                if (isExpanded) Res.string.session_room_state_description_expanded
+                else Res.string.session_room_state_description_collapsed
             )
             Action(
                 label = roomName,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -290,7 +292,7 @@ private fun FeedbackPanel(
             )
             Spacer(Modifier.height(16.dp))
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().selectableGroup(),
                 horizontalArrangement = Arrangement.SpaceEvenly,
             ) {
                 val feedbackEmotions = remember {
@@ -298,10 +300,15 @@ private fun FeedbackPanel(
                 }
                 val hapticFeedback = LocalHapticFeedback.current
                 feedbackEmotions.forEach { emotion ->
+                    val selected = selectedEmotion == emotion
                     KodeeIconLarge(
                         emotion = emotion,
-                        selected = selectedEmotion == emotion,
-                        modifier = Modifier.clickable(indication = null, interactionSource = null) {
+                        selected = selected,
+                        modifier = Modifier.selectable(
+                            selected = selected,
+                            indication = null,
+                            interactionSource = null
+                        ) {
                             val newEmotion = if (emotion == selectedEmotion) null else emotion
                             if (userSignedIn) {
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SettingsScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -130,7 +132,10 @@ private fun SettingsScreenImpl(
             ) {
                 Text(
                     text = stringResource(AppRes.string.settings_theme_title),
-                    style = KotlinConfTheme.typography.h2
+                    style = KotlinConfTheme.typography.h2,
+                    modifier = Modifier.semantics {
+                        heading()
+                    }
                 )
                 ThemeSelector(
                     currentTheme = currentTheme,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SettingsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.EaseOutQuad
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,6 +18,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -169,7 +170,7 @@ private fun ThemeSelector(
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = modifier
+        modifier = modifier.selectableGroup()
     ) {
         themes.forEach { theme ->
             ThemeBox(
@@ -192,12 +193,13 @@ private fun ThemeBox(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
-            .clickable(
+            .selectable(
+                selected = isSelected,
                 onClick = onClick,
+                role = Role.RadioButton,
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() },
             )
-            .semantics(mergeDescendants = true) {},
     ) {
         Box(
             contentAlignment = Alignment.Center,

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SettingsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinconfapp.shared.generated.resources.Res
+import kotlinconfapp.shared.generated.resources.settings_notifications_title
 import kotlinconfapp.shared.generated.resources.settings_theme_dark
 import kotlinconfapp.shared.generated.resources.settings_theme_light
 import kotlinconfapp.shared.generated.resources.settings_theme_system
@@ -55,7 +56,6 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.kotlinconf.LocalFlags
 import org.jetbrains.kotlinconf.ScreenWithTitle
 import org.jetbrains.kotlinconf.Theme
-import org.jetbrains.kotlinconf.ui.components.Divider
 import org.jetbrains.kotlinconf.ui.components.Text
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
 import org.koin.compose.viewmodel.koinViewModel
@@ -124,40 +124,39 @@ private fun SettingsScreenImpl(
         onBack = onBack,
         modifier = modifier,
     ) {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(24.dp),
-            modifier = Modifier.padding(vertical = 16.dp)
-        ) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Text(
-                    text = stringResource(AppRes.string.settings_theme_title),
-                    style = KotlinConfTheme.typography.h2,
-                    modifier = Modifier.semantics {
-                        heading()
-                    }
-                )
-                ThemeSelector(
-                    currentTheme = currentTheme,
-                    onThemeChange = onThemeChange,
-                )
-            }
+        Column {
+            SectionHeading(stringResource(AppRes.string.settings_theme_title))
+            ThemeSelector(currentTheme, onThemeChange)
+
+            Spacer(Modifier.height(24.dp))
 
             if (LocalFlags.current.supportsNotifications) {
-                Divider(thickness = 1.dp, color = KotlinConfTheme.colors.strokePale)
-
                 val notificationSettings = viewModel.notificationSettings.collectAsStateWithLifecycle().value
-                if (notificationSettings != null)
+                if (notificationSettings != null) {
+                    SectionHeading(stringResource(AppRes.string.settings_notifications_title))
                     NotificationSettings(
                         notificationSettings = notificationSettings,
                         onChangeSettings = { newSettings ->
                             viewModel.setNotificationSettings(newSettings)
                         }
                     )
+                }
             }
         }
     }
+}
+
+@Composable
+private fun SectionHeading(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = KotlinConfTheme.typography.h2,
+        modifier = modifier.semantics { heading() }
+            .padding(top = 16.dp, bottom = 12.dp)
+    )
 }
 
 private val themes = listOf(Theme.SYSTEM, Theme.DARK, Theme.LIGHT)

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakerDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakerDetailScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinconfapp.shared.generated.resources.Res
@@ -95,6 +97,9 @@ fun SpeakerDetailScreen(
                         style = KotlinConfTheme.typography.h2,
                         color = KotlinConfTheme.colors.primaryText,
                         selectable = true,
+                        modifier = Modifier.semantics {
+                            heading()
+                        }
                     )
 
                     Spacer(Modifier.height(4.dp))

--- a/ui-components/src/commonMain/composeResources/values/strings.xml
+++ b/ui-components/src/commonMain/composeResources/values/strings.xml
@@ -6,11 +6,19 @@
 
     <!-- Actions -->
     <string name="action_bookmark">Bookmark</string>
+    <string name="action_bookmark_talk">Bookmark %1$s</string>
+    <string name="action_remove_talk_from_bookmarks">Remove %1$s from bookmarks</string>
+
     <string name="action_error_reload">Reload</string>
 
     <string name="action_rate_negative">Vote negative</string>
     <string name="action_rate_neutral">Vote neutral</string>
     <string name="action_rate_positive">Vote positive</string>
+
+    <string name="action_state_description_expanded">Expanded</string>
+    <string name="action_state_description_collapsed">Collapsed</string>
+    <string name="action_state_description_bookmarked">Bookmarked</string>
+    <string name="action_state_description_not_bookmarked">Not bookmarked</string>
 
     <!-- Components -->
     <string name="feedback_form_type_something">Type something</string>

--- a/ui-components/src/commonMain/composeResources/values/strings.xml
+++ b/ui-components/src/commonMain/composeResources/values/strings.xml
@@ -6,8 +6,8 @@
 
     <!-- Actions -->
     <string name="action_bookmark">Bookmark</string>
-    <string name="action_bookmark_talk">Bookmark %1$s</string>
-    <string name="action_remove_talk_from_bookmarks">Remove %1$s from bookmarks</string>
+    <string name="action_bookmark_session">Bookmark %1$s</string>
+    <string name="action_remove_session_from_bookmarks">Remove %1$s from bookmarks</string>
 
     <string name="action_error_reload">Reload</string>
 
@@ -36,4 +36,6 @@
     <string name="talk_card_your_feedback">Your feedback</string>
     <string name="talk_card_how_was_the_talk">How was the talk?</string>
     <string name="talk_card_how_was_the_workshop">How was the workshop?</string>
+    <string name="talk_card_icon_desc_education">Education</string>
+    <string name="talk_card_icon_desc_codelab">Codelab</string>
 </resources>

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/DayHeader.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/DayHeader.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -55,7 +56,9 @@ fun DayHeader(
             .background(colorGradient)
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 6.dp)
-            .semantics(mergeDescendants = true) {},
+            .semantics(mergeDescendants = true) {
+                heading()
+            },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/ErrorLoading.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/ErrorLoading.kt
@@ -38,6 +38,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.ui_components.generated.resources.Res
@@ -64,7 +67,15 @@ fun MinorError(
     message: String,
     modifier: Modifier = Modifier,
 ) {
-    ErrorText(message, modifier.fillMaxWidth().padding(32.dp))
+    ErrorText(
+        message,
+        modifier
+            .fillMaxWidth()
+            .padding(32.dp)
+            .semantics {
+                liveRegion = LiveRegionMode.Assertive
+            }
+    )
 }
 
 @Composable
@@ -82,7 +93,12 @@ fun MajorError(
             contentDescription = null,
         )
         Spacer(Modifier.height(16.dp))
-        ErrorText(message)
+        ErrorText(
+            message = message,
+            modifier = Modifier.semantics {
+                liveRegion = LiveRegionMode.Assertive
+            }
+        )
     }
 }
 

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
@@ -37,6 +37,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.ui_components.generated.resources.Res
 import kotlinconfapp.ui_components.generated.resources.filter_by_tags
@@ -169,6 +172,9 @@ private fun FilterItemGroup(
             text = title,
             style = KotlinConfTheme.typography.text2,
             color = KotlinConfTheme.colors.noteText,
+            modifier = Modifier.semantics {
+                heading()
+            }
         )
         FlowRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
@@ -80,10 +80,8 @@ fun Filters(
             .verticalScroll(rememberScrollState()),
     ) {
         val stateDesc = stringResource(
-            resource =  if (isExpanded) 
-                Res.string.action_state_description_expanded
-            else
-                Res.string.action_state_description_collapsed
+            if (isExpanded) Res.string.action_state_description_expanded
+            else Res.string.action_state_description_collapsed
         )
         Row(
             horizontalArrangement = Arrangement.Center,

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -188,6 +189,7 @@ private fun FilterItemGroup(
             }
         )
         FlowRow(
+            modifier = Modifier.selectableGroup(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Filters.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.ui_components.generated.resources.Res
+import kotlinconfapp.ui_components.generated.resources.action_state_description_collapsed
+import kotlinconfapp.ui_components.generated.resources.action_state_description_expanded
 import kotlinconfapp.ui_components.generated.resources.filter_by_tags
 import kotlinconfapp.ui_components.generated.resources.filter_label_category
 import kotlinconfapp.ui_components.generated.resources.filter_label_level
@@ -76,6 +78,12 @@ fun Filters(
             .background(KotlinConfTheme.colors.tileBackground)
             .verticalScroll(rememberScrollState()),
     ) {
+        val stateDesc = stringResource(
+            resource =  if (isExpanded) 
+                Res.string.action_state_description_expanded
+            else
+                Res.string.action_state_description_collapsed
+        )
         Row(
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
@@ -90,6 +98,9 @@ fun Filters(
                 .heightIn(min = 46.dp)
                 .padding(vertical = 11.dp)
                 .fillMaxWidth()
+                .semantics {
+                    stateDescription = stateDesc
+                }
         ) {
             val iconRotation by animateFloatAsState(if (isExpanded) 0f else 180f)
             Action(

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/FiltersTag.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/FiltersTag.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -16,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
@@ -55,7 +57,11 @@ fun FilterTag(
                 color = strokeColor,
                 shape = FilterTagShape,
             )
-            .clickable(onClick = { onSelect(!selected) })
+            .selectable(
+                selected = selected,
+                onClick = { onSelect(!selected) },
+                role = Role.RadioButton
+            )
             .background(backgroundColor)
             .padding(horizontal = 12.dp, vertical = 10.dp),
         contentAlignment = Alignment.Center,

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/MainHeader.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/MainHeader.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.ui_components.generated.resources.Res
 import kotlinconfapp.ui_components.generated.resources.arrow_left_24
@@ -140,7 +142,7 @@ fun MainHeaderTitleBar(
         }
         Text(
             text = title,
-            modifier = Modifier.align(Alignment.Center),
+            modifier = Modifier.align(Alignment.Center).semantics { heading() },
             style = KotlinConfTheme.typography.h3,
             color = KotlinConfTheme.colors.primaryText,
         )

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/PageTitle.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/PageTitle.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import kotlinconfapp.ui_components.generated.resources.Res
@@ -97,6 +98,7 @@ fun PageTitle(
             style = KotlinConfTheme.typography.h1,
             color = KotlinConfTheme.colors.primaryText,
             selectable = true,
+            modifier = Modifier.semantics { heading() }
         )
         FlowRow(
             horizontalArrangement = Arrangement.spacedBy(4.dp),

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/SettingsItem.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/SettingsItem.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlinconf.ui.components
 
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -17,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
@@ -41,15 +43,15 @@ fun SettingsItem(
             .fillMaxWidth()
             .clip(SettingsItemShape)
             .background(KotlinConfTheme.colors.tileBackground)
-            .padding(16.dp)
             .toggleable(
                 value = enabled,
                 enabled = true,
                 role = Role.Switch,
                 onValueChange = { onToggle(!enabled) },
                 interactionSource = interactionSource,
-                indication = null,
-            ),
+                indication = LocalIndication.current,
+            )
+            .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -72,7 +74,9 @@ fun SettingsItem(
         Toggle(
             enabled = enabled,
             onToggle = onToggle,
-            modifier = Modifier.clearAndSetSemantics {},
+            modifier = Modifier
+                .focusProperties { canFocus = false }
+                .clearAndSetSemantics {},
             interactionSource = interactionSource,
         )
     }

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Switcher.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Switcher.kt
@@ -3,14 +3,14 @@ package org.jetbrains.kotlinconf.ui.components
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -58,9 +58,9 @@ private fun SwitcherItem(
                 color = strokeColor,
                 shape = SwitcherItemShape,
             )
-            .toggleable(
-                value = selected,
-                onValueChange = { onClick() },
+            .selectable(
+                selected = selected,
+                onClick = { onClick() },
                 role = Role.Tab
             )
             .background(backgroundColor)
@@ -92,8 +92,9 @@ fun Switcher(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp)
+        modifier = modifier.selectableGroup(),
+        horizontalArrangement = Arrangement
+            .spacedBy(4.dp)
     ) {
         items.forEachIndexed { index, label ->
             SwitcherItem(

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Switcher.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Switcher.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
@@ -56,7 +58,11 @@ private fun SwitcherItem(
                 color = strokeColor,
                 shape = SwitcherItemShape,
             )
-            .clickable(onClick = onClick)
+            .toggleable(
+                value = selected,
+                onValueChange = { onClick() },
+                role = Role.Tab
+            )
             .background(backgroundColor)
             .padding(horizontal = 16.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center,

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
@@ -27,6 +27,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
@@ -492,17 +494,24 @@ private fun FeedbackBlock(
                 }
             }
             Spacer(Modifier.weight(1f))
-            Row {
+            Row(
+                modifier = Modifier.selectableGroup()
+            ) {
                 val feedbackEmotions = remember {
                     listOf(Emotion.Negative, Emotion.Neutral, Emotion.Positive)
                 }
                 val hapticFeedback = LocalHapticFeedback.current
                 feedbackEmotions.forEach { emotion ->
+                    val selected = selectedEmotion == emotion
                     KodeeIconSmall(
                         emotion = emotion,
-                        selected = selectedEmotion == emotion,
+                        selected = selected,
                         modifier = Modifier
-                            .clickable(indication = null, interactionSource = null) {
+                            .selectable(
+                                selected = selected,
+                                indication = null,
+                                interactionSource = null
+                            ) {
                                 if (userSignedIn) {
                                     hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
                                     selectedEmotion = if (emotion == selectedEmotion) null else emotion

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
@@ -439,16 +439,20 @@ private fun FeedbackBlock(
     var feedbackExpanded by rememberSaveable { mutableStateOf(false) }
     var feedbackText by rememberSaveable { mutableStateOf("") }
 
+    val interactionModifier = if (selectedEmotion != null) {
+        Modifier.clickable(
+            indication = null,
+            interactionSource = remember { MutableInteractionSource() },
+        ) {
+            feedbackExpanded = !feedbackExpanded
+        }
+    } else {
+        Modifier
+    }
+
     Column(
         Modifier
-            .clickable(
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() },
-            ) {
-                if (selectedEmotion != null) {
-                    feedbackExpanded = !feedbackExpanded
-                }
-            },
+            .then(interactionModifier),
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
@@ -58,7 +59,10 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import kotlinconfapp.ui_components.generated.resources.Res
-import kotlinconfapp.ui_components.generated.resources.action_bookmark
+import kotlinconfapp.ui_components.generated.resources.action_bookmark_talk
+import kotlinconfapp.ui_components.generated.resources.action_remove_talk_from_bookmarks
+import kotlinconfapp.ui_components.generated.resources.action_state_description_bookmarked
+import kotlinconfapp.ui_components.generated.resources.action_state_description_not_bookmarked
 import kotlinconfapp.ui_components.generated.resources.arrow_right_24
 import kotlinconfapp.ui_components.generated.resources.bookmark_24
 import kotlinconfapp.ui_components.generated.resources.bookmark_24_fill
@@ -237,6 +241,12 @@ private fun TopBlock(
                 if (bookmarked) KotlinConfTheme.colors.orangeText
                 else KotlinConfTheme.colors.primaryText
             )
+            val stateDesc = stringResource(
+                resource =  if (bookmarked)
+                    Res.string.action_state_description_bookmarked
+                else
+                    Res.string.action_state_description_not_bookmarked
+            )
             Icon(
                 modifier = Modifier
                     .toggleable(
@@ -246,12 +256,19 @@ private fun TopBlock(
                         interactionSource = null,
                         indication = null,
                     )
-                    .size(24.dp),
+                    .size(24.dp)
+                    .semantics {
+                        stateDescription = stateDesc
+                    },
                 painter = painterResource(
                     if (bookmarked) Res.drawable.bookmark_24_fill
                     else Res.drawable.bookmark_24
                 ),
-                contentDescription = stringResource(Res.string.action_bookmark),
+                contentDescription = stringResource(
+                    if (bookmarked) Res.string.action_bookmark_talk
+                    else Res.string.action_remove_talk_from_bookmarks,
+                    title
+                ),
                 tint = iconColor,
             )
         }
@@ -342,7 +359,11 @@ private fun InlineIconContent(status: TalkStatus, placeholder: String) {
                 else -> Res.drawable.session_codelab // Shouldn't happen, but let's not throw
             }
         ),
-        contentDescription = null,
+        contentDescription = when (placeholder) {
+            eduPlaceholder -> "Education"
+            codelabPlaceholder -> "Codelab"
+            else -> null
+        },
         tint = textColor,
     )
 }

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
@@ -61,8 +61,8 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import kotlinconfapp.ui_components.generated.resources.Res
-import kotlinconfapp.ui_components.generated.resources.action_bookmark_talk
-import kotlinconfapp.ui_components.generated.resources.action_remove_talk_from_bookmarks
+import kotlinconfapp.ui_components.generated.resources.action_bookmark_session
+import kotlinconfapp.ui_components.generated.resources.action_remove_session_from_bookmarks
 import kotlinconfapp.ui_components.generated.resources.action_state_description_bookmarked
 import kotlinconfapp.ui_components.generated.resources.action_state_description_not_bookmarked
 import kotlinconfapp.ui_components.generated.resources.arrow_right_24
@@ -74,6 +74,8 @@ import kotlinconfapp.ui_components.generated.resources.session_codelab
 import kotlinconfapp.ui_components.generated.resources.session_education
 import kotlinconfapp.ui_components.generated.resources.talk_card_how_was_the_talk
 import kotlinconfapp.ui_components.generated.resources.talk_card_how_was_the_workshop
+import kotlinconfapp.ui_components.generated.resources.talk_card_icon_desc_codelab
+import kotlinconfapp.ui_components.generated.resources.talk_card_icon_desc_education
 import kotlinconfapp.ui_components.generated.resources.talk_card_your_feedback
 import kotlinconfapp.ui_components.generated.resources.up_24
 import org.jetbrains.compose.resources.painterResource
@@ -267,8 +269,8 @@ private fun TopBlock(
                     else Res.drawable.bookmark_24
                 ),
                 contentDescription = stringResource(
-                    if (bookmarked) Res.string.action_bookmark_talk
-                    else Res.string.action_remove_talk_from_bookmarks,
+                    if (bookmarked) Res.string.action_bookmark_session
+                    else Res.string.action_remove_session_from_bookmarks,
                     title
                 ),
                 tint = iconColor,
@@ -362,8 +364,8 @@ private fun InlineIconContent(status: TalkStatus, placeholder: String) {
             }
         ),
         contentDescription = when (placeholder) {
-            eduPlaceholder -> "Education"
-            codelabPlaceholder -> "Codelab"
+            eduPlaceholder -> stringResource(Res.string.talk_card_icon_desc_education)
+            codelabPlaceholder -> stringResource(Res.string.talk_card_icon_desc_codelab)
             else -> null
         },
         tint = textColor,

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/TalkCard.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
@@ -224,7 +226,9 @@ private fun TopBlock(
                 tags = tags,
                 textColor = textColor,
                 status = status,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics { heading() }
             )
 
             Spacer(Modifier.width(8.dp))

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Toggle.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Toggle.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -24,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
@@ -66,6 +66,14 @@ fun Toggle(
         Box(
             Modifier.size(ToggleWidth, ToggleHeight)
                 .clip(ToggleBackgroundShape)
+                .focusProperties {
+                    canFocus = false
+                }
+                .clickable(
+                    onClick = { onToggle(!enabled) },
+                    interactionSource = interactionSource,
+                    indication = LocalIndication.current,
+                )
                 .background(toggleColor)
         )
         val xOffset by animateDpAsState(if (enabled) ToggleWidth / 4 else -ToggleWidth / 4)
@@ -78,6 +86,14 @@ fun Toggle(
                 .size(ThumbSize)
                 .clip(ToggleThumbShape)
                 .background(toggleColor)
+                .focusProperties {
+                    canFocus = false
+                }
+                .clickable(
+                    onClick = { onToggle(!enabled) },
+                    interactionSource = interactionSource,
+                    indication = LocalIndication.current,
+                )
                 .drawBehind {
                     drawCircle(color = thumbCenterColor, radius = (size.minDimension / 2) - 2.dp.toPx())
                 }

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Toggle.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Toggle.kt
@@ -66,11 +66,6 @@ fun Toggle(
         Box(
             Modifier.size(ToggleWidth, ToggleHeight)
                 .clip(ToggleBackgroundShape)
-                .clickable(
-                    onClick = { onToggle(!enabled) },
-                    interactionSource = interactionSource,
-                    indication = LocalIndication.current,
-                )
                 .background(toggleColor)
         )
         val xOffset by animateDpAsState(if (enabled) ToggleWidth / 4 else -ToggleWidth / 4)
@@ -83,11 +78,6 @@ fun Toggle(
                 .size(ThumbSize)
                 .clip(ToggleThumbShape)
                 .background(toggleColor)
-                .clickable(
-                    onClick = { onToggle(!enabled) },
-                    interactionSource = interactionSource,
-                    indication = LocalIndication.current,
-                )
                 .drawBehind {
                     drawCircle(color = thumbCenterColor, radius = (size.minDimension / 2) - 2.dp.toPx())
                 }


### PR DESCRIPTION
First patch of accessibility improvements. They consist of the following:
- Adding a couple of content descriptions that were missing/incorrectly set.
- Adding state descriptions for component benefitting from them.
- Annotating headers for easier navigation for screen reader (and other assistive tech utilizing them) users
- Marking errors as live regions so that they'd be announced
- Changing some `clickable` modifiers to `selectable` or `toggleable` to match the semantics to the usage of the element
- Fixing some issues with large text (see example below)

In general, the other changes are about the semantics changing + some tab stops disappearing, the only UI change is the privacy policy screen's scrollability:

<table>
<tr>
  <td>Before</td>
  <td>After</td>
</tr>
<tr>
  <td><video src="https://github.com/user-attachments/assets/3002c39c-971f-4a24-898d-98f349791c73" controls /></td>
  <td><video src="https://github.com/user-attachments/assets/851b7cb3-43ce-49f6-a8dc-b4a4fe0fddc2" controls /></td>
</tr>
</table>