### PR TITLE
Enable Gradle Caching (GCC, and build-cache)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,11 @@
 #Gradle
 org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
 kotlin.daemon.jvmargs=-Xmx4G
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn
+org.gradle.configuration-cache.parallel=true
+org.gradle.caching=true
+org.gradle.parallel=true
 
 #Kotlin
 kotlin.code.style=official

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -36,6 +36,8 @@ kotlin {
     wasmJs {
         binaries.executable()
         browser {
+            val projectDir = project.projectDir.path
+            val rootDir = project.rootDir.path
             commonWebpackConfig {
                 outputFileName = "kotlin-app-wasm-js.js"
                 devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
@@ -48,8 +50,8 @@ kotlin {
 
                     static = (static ?: mutableListOf()).apply {
                         // Serve sources to debug inside a browser
-                        add(project.projectDir.path)
-                        add(project.rootDir.path)
+                        add(projectDir)
+                        add(rootDir)
                     }
                 }
             }


### PR DESCRIPTION
GCC: Gradle Configuration Cache will increase hot reload speeds
Local Build Cache: Will help with switching branches