### PR TITLE
Fix padding on speaker detail screen

### DIFF
--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakerDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SpeakerDetailScreen.kt
@@ -88,9 +88,9 @@ fun SpeakerDetailScreen(
                 ScrollToTopHandler(scrollState)
                 Column(
                     modifier = Modifier
+                        .verticalScroll(scrollState)
                         .padding(vertical = 16.dp, horizontal = 12.dp)
-                        .padding(bottomInsetPadding())
-                        .verticalScroll(scrollState),
+                        .padding(bottomInsetPadding()),
                 ) {
                     Text(
                         text = currentSpeaker.name,


### PR DESCRIPTION
Fix the issue where the padding was previously applied outside of the scrollable area. The content now correctly reaches the top toolbar when scrolled:

https://github.com/user-attachments/assets/7b740bac-7bac-4aea-9bcc-2f9abde7c872



Modifier ordering is hard