### PR TITLE
A11y: Carousel semantics

### DIFF
--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -35,7 +35,13 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.CollectionItemInfo
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.collectionItemInfo
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -487,12 +493,20 @@ private fun ScheduleList(
                                 )
                                 HorizontalPager(
                                     state = pagerState,
-                                    modifier = Modifier.fillMaxWidth(),
+                                    modifier = Modifier.fillMaxWidth()
+                                        .semantics {
+                                            role = Role.Carousel
+                                            collectionInfo = CollectionInfo(
+                                                rowCount = 1,
+                                                columnCount = workshops.size
+                                            )
+                                    },
                                     beyondViewportPageCount = 1,
                                     contentPadding = PaddingValues(horizontal = 24.dp),
                                 ) { pageIndex ->
+                                    val workshopIndex = pageIndex % workshops.size
                                     SessionCard(
-                                        session = workshops[pageIndex % workshops.size],
+                                        session = workshops[workshopIndex],
                                         isSearch = isSearch,
                                         userSignedIn = userSignedIn,
                                         onBookmark = onBookmark,
@@ -502,6 +516,14 @@ private fun ScheduleList(
                                         onSession = onSession,
                                         modifier = Modifier
                                             .padding(horizontal = 8.dp, vertical = 8.dp)
+                                            .semantics {
+                                                collectionItemInfo = CollectionItemInfo(
+                                                    rowIndex = 1,
+                                                    columnIndex = workshopIndex,
+                                                    columnSpan = 1,
+                                                    rowSpan = 1
+                                                )
+                                            }
                                     )
                                 }
                                 ScrollIndicator(

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -457,6 +457,9 @@ private fun ScheduleList(
                             modifier = Modifier
                                 .padding(horizontal = 12.dp)
                                 .padding(top = 24.dp, bottom = 8.dp)
+                                .semantics {
+                                    heading()
+                                }
                         )
                     }
 

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/StartNotificationsScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/StartNotificationsScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinconfapp.shared.generated.resources.kodee_notifications
@@ -66,7 +68,10 @@ fun StartNotificationsScreen(
             )
             Text(
                 stringResource(AppRes.string.notifications_title),
-                style = KotlinConfTheme.typography.h1
+                style = KotlinConfTheme.typography.h1,
+                modifier = Modifier.semantics {
+                    heading()
+                }
             )
             Text(
                 stringResource(AppRes.string.notifications_description),

--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/ServiceEvents.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/ServiceEvents.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
@@ -34,7 +35,7 @@ private fun ServiceEventItem(
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = modifier.padding(16.dp)
+        modifier = modifier.padding(16.dp).semantics(mergeDescendants = true) {}
     ) {
         Text(
             text = event.title,


### PR DESCRIPTION
This PR adds some more semantics (headings & merges service items into one block), and adds correct semantics for the workshop carousel. 

For some reason, the `HorizontalPager` and its child items don't have the correct list semantics, so I added `collectionItemInfo` and `collectionInfo` to them. And even if everything worked as expected with `HorizontalPager`, there's a problem with the page count; now it has `Int.MAX_SIZE` as the size of the list of items (`pageCount`), so instead of the seven items the list has, `Int.MAX_SIZE` would be announced. These changes fix that as well. 