### PR TITLE
Fix unnecessary scrolls-to-top

### DIFF
--- a/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/ScrollToTopHandler.kt
+++ b/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/ScrollToTopHandler.kt
@@ -79,11 +79,16 @@ private fun createDelegate(
             scrollingToTop = false
         }
 
+        private var firstScroll = true
         private var scrollingToTop = false
         private var lastKnownOffset = 1.0
 
         // Sync from Native to Compose
         override fun scrollViewDidScroll(scrollView: UIScrollView) {
+            if (firstScroll) {
+                firstScroll = false
+                return
+            }
             if (scrollingToTop) {
                 return
             }


### PR DESCRIPTION
The `UIScrollView` triggers `scrollViewDidScroll` when it's first created, just to signal its initial 0 state. If we already an had existing scroll position (for example, we're navigating back to a previous screen that uses this handler), this forces us to scroll back to the top.

This change ignores this first `scrollViewDidScroll` invocation so that we don't reset state when we shouldn't.