### PR TITLE
Disable all transitions across Main screen tabs

### DIFF
--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/MainScreen.kt
@@ -90,8 +90,8 @@ fun MainScreen(
                 .weight(1f),
             enterTransition = { EnterTransition.None },
             exitTransition = { ExitTransition.None },
-            popEnterTransition = { fadeIn() },
-            popExitTransition = { fadeOut() },
+            popEnterTransition = { EnterTransition.None },
+            popExitTransition = { ExitTransition.None },
         ) {
             composable<InfoScreen> {
                 MainBackHandler()


### PR DESCRIPTION
Navigating from anything back to the Schedule tab counts as a pop transition, and shows up as a fade on iOS. Here we'll just remove all navigations between tabs on all platforms. This is aligned with popular apps even for Android - they just don't have predictive back animations for these tabbed screens.