### PR TITLE
Fix potential crash by replacing first() with firstOrNull() in FlagsManager initialization

### DIFF
--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/FlagsManager.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/FlagsManager.kt
@@ -2,7 +2,7 @@ package org.jetbrains.kotlinconf
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -20,7 +20,7 @@ class FlagsManager(
 
     init {
         scope.launch {
-            val storedFlags = storage.getFlags().first()
+            val storedFlags = storage.getFlags().firstOrNull()
             if (storedFlags == null) {
                 storage.setFlags(platformFlags)
             }


### PR DESCRIPTION
### Background
In `FlagsManager`, during initialization, the code currently retrieves the stored flags by calling `storage.getFlags().first()`.  
If the `Flow` is empty (i.e., no flags have been stored yet), `first()` throws a `NoSuchElementException`, which can crash the application.

Given that the code checks whether `storedFlags` is `null`, it is more appropriate and safer to use `firstOrNull()` instead.  
This way, if the `Flow` does not emit any value, it returns `null` instead of crashing, allowing the initialization logic to proceed correctly.

Additionally, since the `flags` property already handles fallback to `platformFlags` when necessary (via `map { it ?: platformFlags }` and `stateIn`),  
this change ensures consistency and robustness without altering the intended behavior.

---

### Changes
- Replace `first()` with `firstOrNull()` when retrieving stored flags in `FlagsManager.init`.

---

### Why
- Prevents potential `NoSuchElementException` and application crashes when no flags have been stored.
- Aligns with the existing `null` check (`storedFlags == null`) in the initialization logic.
- Improves overall code robustness and consistency.

---
