### PR TITLE
Apply safeDrawing window inset in SessionScreen

### DIFF
--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/SessionScreen.kt
@@ -16,11 +16,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.selectable
@@ -85,7 +88,6 @@ import org.jetbrains.kotlinconf.ui.components.TopMenuButton
 import org.jetbrains.kotlinconf.ui.theme.KotlinConfTheme
 import org.jetbrains.kotlinconf.utils.FadingAnimationSpec
 import org.jetbrains.kotlinconf.utils.bottomInsetPadding
-import org.jetbrains.kotlinconf.utils.topInsetPadding
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import kotlinconfapp.ui_components.generated.resources.Res as UiRes
@@ -118,7 +120,7 @@ fun SessionScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(color = KotlinConfTheme.colors.mainBackground)
-            .padding(topInsetPadding())
+            .windowInsetsPadding(WindowInsets.safeDrawing)
     ) {
         MainHeaderTitleBar(
             title = stringResource(Res.string.session_title),


### PR DESCRIPTION
This PR addresses https://github.com/JetBrains/kotlinconf-app/issues/419.

It uses the [`safeDrawing()`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#(androidx.compose.foundation.layout.WindowInsets.Companion).safeDrawing()) window inset API to ensure that the buttons are safely drawn and no gestures/cutouts are overlapping.

| - | - |
|--------|--------|
| Before | <img src="https://github.com/user-attachments/assets/a4cc41fd-f86d-45b3-896a-453b89ad96d2" /> |
| After | <img src="https://github.com/user-attachments/assets/11d9195d-751d-41b9-9cfe-572db68615d4" /> | 
