### PR TITLE
Various design fixes

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -124,7 +124,7 @@ We will process your data in accordance with the App Privacy Notice. You can adj
         <item quantity="other">%1$d sessions found</item>
     </plurals>
 
-    <string name="session_title">Schedule</string>
+    <string name="session_title">Session</string>
     <string name="session_your_feedback">Your feedback</string>
     <string name="session_screen_error">The details of this session are not available at the moment.</string>
     <string name="session_watch_video">Watch the recording</string>

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/DeveloperMenuScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/DeveloperMenuScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
@@ -206,7 +207,9 @@ fun DeveloperMenuScreen(
                     Image(
                         painter = painterResource(Res.drawable.kodee_frightened),
                         contentDescription = null,
-                        modifier = Modifier.align(Alignment.CenterHorizontally).padding(bottom = 12.dp)
+                        modifier = Modifier.align(Alignment.CenterHorizontally)
+                            .padding(bottom = 12.dp)
+                            .sizeIn(maxWidth = 300.dp, maxHeight = 300.dp)
                     )
                     Spacer(Modifier.height(24.dp))
                     Text(

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleScreen.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -441,6 +443,7 @@ private fun ScheduleList(
             scheduleItems,
             key = {
                 when (it) {
+                    is DaySeparatorItem -> it.id
                     is DayHeaderItem -> it.value.date.toString()
                     is ServiceEventGroupItem -> it.value.map { it.id.id }
                     is ServiceEventItem -> it.value.id.id
@@ -453,6 +456,10 @@ private fun ScheduleList(
         ) { item ->
             Box(Modifier.animateItem()) {
                 when (item) {
+                    is DaySeparatorItem -> {
+                        Spacer(modifier = Modifier.height(48.dp))
+                    }
+
                     is DayHeaderItem -> {
                         val date = item.value.date
                         val dayValues = DayValues.map[date]
@@ -463,7 +470,7 @@ private fun ScheduleList(
                             line2 = dayValues?.line2 ?: "",
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(top = 8.dp)
+                                .padding(vertical = 16.dp)
                                 .semantics { heading() }
                         )
                     }
@@ -475,9 +482,7 @@ private fun ScheduleList(
                             modifier = Modifier
                                 .padding(horizontal = 12.dp)
                                 .padding(top = 24.dp, bottom = 8.dp)
-                                .semantics {
-                                    heading()
-                                }
+                                .semantics { heading() }
                         )
                     }
 

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlinconf.Day
 import org.jetbrains.kotlinconf.Score
 import org.jetbrains.kotlinconf.SessionCardView
 import org.jetbrains.kotlinconf.SessionId
+import org.jetbrains.kotlinconf.SessionState
 import org.jetbrains.kotlinconf.TagValues
 import org.jetbrains.kotlinconf.TimeProvider
 import org.jetbrains.kotlinconf.TimeSlot
@@ -29,6 +30,8 @@ import org.jetbrains.kotlinconf.utils.containsDiacritics
 import org.jetbrains.kotlinconf.utils.removeDiacritics
 
 sealed interface ScheduleListItem
+
+data class DaySeparatorItem(val id: String) : ScheduleListItem
 
 data class DayHeaderItem(val value: Day) : ScheduleListItem
 
@@ -176,7 +179,7 @@ class ScheduleViewModel(
         days: List<Day>,
         searchQuery: String,
         selectedTags: List<String>,
-    ): List<ScheduleListItem> = buildList {
+    ): List<SessionItem> = buildList {
         for (day in days) {
             for (timeSlot in day.timeSlots) {
                 for (session in timeSlot.sessions) {
@@ -211,7 +214,10 @@ class ScheduleViewModel(
         var seenPastSlot = false
 
         val items = buildList {
-            days.forEach { day ->
+            days.forEachIndexed { index, day ->
+                if (index > 0) {
+                    add(DaySeparatorItem("day-separator-$index"))
+                }
                 add(DayHeaderItem(day))
 
                 day.timeSlots.forEachIndexed { index, timeSlot ->

--- a/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/screens/ScheduleViewModel.kt
@@ -199,7 +199,7 @@ class ScheduleViewModel(
                 }
             }
         }
-    }
+    }.sortedBy { it.value.state == SessionState.Past }
 
     private fun buildNonSearchItems(
         days: List<Day>,


### PR DESCRIPTION
Updated spacing between days in the schedule:

![image](https://github.com/user-attachments/assets/8b29ec74-31f2-4766-9f94-7457bfcca88e)

---

Sorting: past sessions at the end of search results, instead of sorted by time

![image](https://github.com/user-attachments/assets/35599807-bdb9-43c0-a807-6bb4bcaf5a24)

---

New title for session detail pages, simply "Session":

![image](https://github.com/user-attachments/assets/f7f1677d-f6e4-4ed1-88dc-5656598d4906)
