### PR TITLE
Remove `KmpNotifier` library export from iOS source set

### DIFF
--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -51,7 +51,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         _ application: UIApplication,
         didReceiveRemoteNotification userInfo: [AnyHashable: Any]
     ) async -> UIBackgroundFetchResult {
-        NotifierManager.shared.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)
+        IOSNotificationsKt.handleRemoteNotification(userInfo: userInfo)
         return UIBackgroundFetchResult.newData
     }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -75,7 +75,6 @@ kotlin {
         it.binaries.framework {
             baseName = "shared"
             isStatic = true
-            export(libs.kmpnotifier)
         }
     }
 

--- a/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/IOSNotifications.kt
+++ b/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/IOSNotifications.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlinconf
 
+import com.mmk.kmpnotifier.extensions.onApplicationDidReceiveRemoteNotification
 import com.mmk.kmpnotifier.extensions.onNotificationClicked
 import com.mmk.kmpnotifier.notification.NotifierManager
 import org.jetbrains.kotlinconf.navigation.navigateByLocalNotificationId
@@ -18,4 +19,9 @@ fun handleNotificationResponse(response: UNNotificationResponse) {
 
     // Process push notifications
     NotifierManager.onNotificationClicked(content)
+}
+
+@Suppress("unused") // Called from Swift
+fun handleRemoteNotification(userInfo: Map<Any?, *>) {
+    NotifierManager.onApplicationDidReceiveRemoteNotification(userInfo)
 }


### PR DESCRIPTION
This PR removes the export of the kmpnotifier library in the iOS framework generation.

`IOSNotifications.kt` file in the `iosMain` source set already handles iOS notifications using Kotlin. Exporting `kmpnotifier` library for use on the Swift side is unnecessary. All notification-related logic can be managed within the kotlin side.