### PR TITLE
Add baseline profiles to the Android app #447

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.googleServices)
+    alias(libs.plugins.androidx.baselineprofile)
 }
 
 kotlin {
@@ -49,6 +50,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            baselineProfile {}
         }
     }
 

--- a/baseline-profile/build.gradle.kts
+++ b/baseline-profile/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    id("com.android.test")
+    id("androidx.baselineprofile")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.jetbrains.kotlinconf.baselineprofile"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+        targetSdk = libs.versions.android.targetSdk.get().toInt()
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    targetProjectPath = ":androidApp"
+}
+
+dependencies {
+    implementation(libs.androidx.test.ext.junit)
+    implementation(libs.androidx.test.espresso.core)
+    implementation(libs.androidx.benchmark.macro)
+    implementation(libs.androidx.profileinstaller)
+}
+
+baselineProfile {
+    packageName = "com.jetbrains.kotlinconf"
+}
+
+

--- a/baseline-profile/src/main/kotlin/com/jetbrains/kotlinconf/baselineprofile/BaselineProfileGenerator.kt
+++ b/baseline-profile/src/main/kotlin/com/jetbrains/kotlinconf/baselineprofile/BaselineProfileGenerator.kt
@@ -1,0 +1,31 @@
+package com.jetbrains.kotlinconf.baselineprofile
+
+import androidx.benchmark.macro.junit4.BaselineProfileRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * This test generates a baseline profile for the target application.
+ *
+ * You can run it directly from Android Studio or using the command line:
+ * `./gradlew :baseline-profile:generateBaselineProfile`
+ *
+ * After running, the generated profile will be copied to:
+ * `androidApp/src/release/generated/baselineProfiles/baseline-prof.txt`
+ */
+@RunWith(AndroidJUnit4::class)
+class BaselineProfileGenerator {
+
+    @get:Rule
+    val baselineProfileRule = BaselineProfileRule()
+
+    @Test
+    fun generateBaselineProfile() = baselineProfileRule.collect(
+        packageName = "com.jetbrains.kotlinconf",
+        profileBlock = {
+            startActivityAndWait()
+        }
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,10 @@ logbackClassic = "1.5.18"
 markdown = "0.35.0"
 multiplatform-settings = "1.3.0"
 postgresql = "42.7.3"
+androidx-baselineprofile = "1.4.0"
+androidx-benchmark-macro = "1.4.0"
+androidx-profileinstaller = "1.4.1"
+androidx-test-ext-junit = "1.3.0"
 
 [libraries]
 aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutlibraries" }
@@ -104,6 +108,9 @@ settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "mul
 settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatform-settings" }
 settings-observable = { module = "com.russhwolf:multiplatform-settings-make-observable", version.ref = "multiplatform-settings" }
 settings-serialization = { module = "com.russhwolf:multiplatform-settings-serialization", version.ref = "multiplatform-settings" }
+androidx-benchmark-macro = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidx-benchmark-macro" }
+androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "androidx-profileinstaller" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 
 [plugins]
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
@@ -119,3 +126,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinParcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
+androidx-baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidx-baselineprofile" }


### PR DESCRIPTION
This PR introduces a Baseline Profile focused on optimizing app startup performance, addressing issue #447.

By including pre-compiled paths for initial app launch, this aims to reduce startup latency.

**Changes:**
*   Integrated `androidx.profileinstaller` and the Baseline Profile Gradle plugin.
*   Generated a Baseline Profile specifically targeting critical code paths executed during application startup.

**Testing:**
*   Startup time improvements can be observed after installing this build, particularly on subsequent launches after the profile is compiled by ART.

Closes #447