### PR TITLE
Fix text sizing in the Action component

### DIFF
--- a/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Action.kt
+++ b/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/Action.kt
@@ -60,7 +60,7 @@ fun Action(
                 ActionSize.Large -> KotlinConfTheme.typography.h3
             },
             maxLines = 1,
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(1f, fill = false),
         )
         Icon(
             modifier = Modifier


### PR DESCRIPTION
Before | After
--- | ---
<img width="600" height="800" alt="image" src="https://github.com/user-attachments/assets/aec129e8-6794-4c95-8599-3e93065d8e20" /> | <img width="600" height="800" alt="image" src="https://github.com/user-attachments/assets/96e06294-b1fe-46b2-9314-ca7c26c565fe" />

Fixes #525