### PR TITLE
Add slf4j-nop dependency for desktop app

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,8 +9,8 @@ androidx-activityCompose = "1.10.1"
 androidx-core-ktx = "1.16.0"
 androidx-core-splashscreen = "1.0.1"
 androidx-espresso-core = "3.6.1"
-androidx-navigation = "2.9.0-beta03"
 androidx-lifecycle = "2.9.1"
+androidx-navigation = "2.9.0-beta03"
 androidx-preference = "1.2.1"
 androidx-test-junit = "1.2.1"
 androidx-work-runtime = "2.10.0"
@@ -36,6 +36,7 @@ logbackClassic = "1.5.18"
 markdown = "0.35.0"
 multiplatform-settings = "1.3.0"
 postgresql = "42.7.3"
+slf4jNop = "2.0.17"
 
 [libraries]
 aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutlibraries" }
@@ -104,6 +105,7 @@ settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "mul
 settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatform-settings" }
 settings-observable = { module = "com.russhwolf:multiplatform-settings-make-observable", version.ref = "multiplatform-settings" }
 settings-serialization = { module = "com.russhwolf:multiplatform-settings-serialization", version.ref = "multiplatform-settings" }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4jNop" }
 
 [plugins]
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -153,6 +153,7 @@ kotlin {
             implementation(compose.desktop.currentOs)
             implementation(libs.android.svg)
             implementation(libs.kotlinx.coroutines.swing)
+            implementation(libs.slf4j.nop)
         }
 
         get("webMain").dependencies {


### PR DESCRIPTION
Removes this warning when running the desktop app

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
```