### PR TITLE
Remove year number from app names

### DIFF
--- a/androidApp/src/androidMain/res/values/strings.xml
+++ b/androidApp/src/androidMain/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">KotlinConf 2025</string>
+    <string name="app_name">KotlinConf</string>
 </resources>

--- a/shared/src/jvmMain/composeResources/values/strings.xml
+++ b/shared/src/jvmMain/composeResources/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">KotlinConf 2025</string>
+    <string name="app_name">KotlinConf</string>
 </resources>


### PR DESCRIPTION
The year number doesn't add anything to the app name but can easily make it truncated in a launcher:

<img width="282" height="303" alt="image" src="https://github.com/user-attachments/assets/059366b9-7c2a-4bb7-a9f8-5566ee50b723" />

Let's just make the launcher name "KotlinConf".