### PR TITLE
expose supported languages in iOS settings and allow switching

### DIFF
--- a/app/iosApp/KotlinConf.xcodeproj/project.pbxproj
+++ b/app/iosApp/KotlinConf.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 			knownRegions = (
 				en,
 				Base,
+				de,
 			);
 			mainGroup = 7555FF72242A565900829871;
 			packageReferences = (

--- a/app/iosApp/iosApp/Info.plist
+++ b/app/iosApp/iosApp/Info.plist
@@ -62,5 +62,10 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>de</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Essentially, it adds this language chooser in Settings - Apps - KotlinConf
<img width="603" height="1311" alt="simulator_screenshot_B57685B7-E4B9-41A7-93DA-30B9559AB080" src="https://github.com/user-attachments/assets/290704e3-c22b-4c14-821f-922f9d759ce3" />
