### PR TITLE
Derive topLevelRoute from currentBackstack and simplify state restoration

### DIFF
--- a/app/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/NavState.kt
+++ b/app/shared/src/commonMain/kotlin/org/jetbrains/kotlinconf/navigation/NavState.kt
@@ -1,9 +1,7 @@
 package org.jetbrains.kotlinconf.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSerializable
 import androidx.compose.runtime.snapshots.SnapshotStateList
@@ -12,7 +10,6 @@ import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDe
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.rememberDecoratedNavEntries
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.savedstate.compose.serialization.serializers.MutableStateSerializer
 import androidx.savedstate.compose.serialization.serializers.SnapshotStateListSerializer
 
 @Composable
@@ -21,13 +18,6 @@ fun rememberNavState(
     primaryTopLevelRoute: TopLevelRoute,
     topLevelRoutes: Set<TopLevelRoute>,
 ): NavState {
-
-    val topLevelRoute = rememberSerializable(
-        startRoute, topLevelRoutes,
-        serializer = MutableStateSerializer<TopLevelRoute?>(),
-    ) {
-        mutableStateOf(startRoute as? TopLevelRoute)
-    }
 
     val topLevelBackstacks: Map<TopLevelRoute, SnapshotStateList<AppRoute>> = buildMap {
         topLevelRoutes.forEach { route ->
@@ -46,12 +36,16 @@ fun rememberNavState(
     }
 
     val currentBackstack = rememberSerializable(serializer = SnapshotStateListSerializer()) {
-        mutableStateListOf<AppRoute>()
+        val restoredBackstack = if (startRoute is TopLevelRoute) {
+            topLevelBackstacks[startRoute]!!
+        } else {
+            defaultBackstack
+        }
+        restoredBackstack.toMutableStateList()
     }
 
     return remember(startRoute, topLevelRoutes) {
         NavState(
-            _topLevelRoute = topLevelRoute,
             primaryTopLevelRoute = primaryTopLevelRoute,
             topLevelBackStacks = topLevelBackstacks,
             defaultBackstack = defaultBackstack,
@@ -61,35 +55,21 @@ fun rememberNavState(
 }
 
 class NavState(
-    private val _topLevelRoute: MutableState<TopLevelRoute?>,
     val topLevelBackStacks: Map<TopLevelRoute, SnapshotStateList<AppRoute>>,
     val defaultBackstack: SnapshotStateList<AppRoute>,
     val primaryTopLevelRoute: TopLevelRoute,
     val currentBackstack: SnapshotStateList<AppRoute>,
 ) {
 
-    init {
-        if (currentBackstack.isEmpty()) {
-            val source = if (_topLevelRoute.value != null) {
-                topLevelBackStacks[_topLevelRoute.value]!!
-            } else {
-                defaultBackstack
-            }
-            currentBackstack.addAll(source)
-        }
-    }
-
     var topLevelRoute: TopLevelRoute?
-        get() = _topLevelRoute.value
+        get() = currentBackstack.firstOrNull() as? TopLevelRoute
         set(value) {
-            val oldRoute = _topLevelRoute.value
+            val oldRoute = topLevelRoute
 
             // Save current backstack to the old route's storage
             val oldStorage = if (oldRoute != null) topLevelBackStacks[oldRoute]!! else defaultBackstack
             oldStorage.clear()
             oldStorage.addAll(currentBackstack)
-
-            _topLevelRoute.value = value
 
             // Load new route's backstack into currentBackstack
             val newStorage = if (value != null) topLevelBackStacks[value]!! else defaultBackstack


### PR DESCRIPTION
Besides simplifying a bit, this also fixes web navigation, which couldn't keep track of `topLevelRoute` until now, causing the navigation bar/rail to not update correctly as back/forward navigation happened on the web.