### PR TITLE
Remove unused DI annotations from AndroidLogger

### DIFF
--- a/app/shared/src/androidMain/kotlin/org/jetbrains/kotlinconf/utils/AndroidLogger.kt
+++ b/app/shared/src/androidMain/kotlin/org/jetbrains/kotlinconf/utils/AndroidLogger.kt
@@ -1,12 +1,7 @@
 package org.jetbrains.kotlinconf.utils
 
 import android.util.Log
-import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
 
-@Inject
-@SingleIn(AppScope::class)
 class AndroidLogger : Logger {
     override fun log(tag: String, lazyMessage: () -> String) {
         Log.w(tag, lazyMessage())


### PR DESCRIPTION
 `AndroidLogger` was annotated with `@Inject` and `@SingleIn(AppScope::class)`, but it's instantiated manually in `KotlinConfApplication` and passed into `initApp` as `platformLogger` — it's never resolved through the Metro graph, so the annotations had no effect.
