### PR TITLE
Fix markdown paragraph newline rendering

### DIFF
--- a/app/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/MarkdownView.kt
+++ b/app/ui-components/src/commonMain/kotlin/org/jetbrains/kotlinconf/ui/components/MarkdownView.kt
@@ -40,7 +40,7 @@ fun MarkdownView(
     onCustomUriClick: (String) -> Unit = {},
 ) {
     MarkdownImpl(
-        loadText = { loadText().decodeToString() },
+        loadText = { loadText().decodeToString().replace(Regex("(?<!\\n)\\n(?!\\n)"), " ") },
         modifier = modifier,
         onCustomUriClick = onCustomUriClick,
     )
@@ -53,7 +53,7 @@ fun MarkdownView(
     onCustomUriClick: (String) -> Unit = {},
 ) {
     MarkdownImpl(
-        loadText = { text },
+        loadText = { text.replace(Regex("(?<!\\n)\\n(?!\\n)"), " ") },
         modifier = modifier,
         onCustomUriClick = onCustomUriClick,
     )


### PR DESCRIPTION
Summary
Fix markdown rendering so single newlines inside paragraphs are rendered as spaces instead of unintended line breaks.

Changes
Replaced single newline characters with spaces while preserving paragraph breaks
Applied the fix to both text-based and ByteArray-based markdown loading paths
Testing
Ran project checks successfully using:
./gradlew check