### PR TITLE
Fix Android build for lg-nav branch

### DIFF
--- a/app/androidApp/src/main/kotlin/org/jetbrains/kotlinconf/android/MainActivity.kt
+++ b/app/androidApp/src/main/kotlin/org/jetbrains/kotlinconf/android/MainActivity.kt
@@ -19,6 +19,7 @@ import dev.zacsweers.metrox.android.ActivityKey
 import org.jetbrains.kotlinconf.App
 import org.jetbrains.kotlinconf.EXTRA_LOCAL_NOTIFICATION_ID
 import org.jetbrains.kotlinconf.PermissionHandler
+import org.jetbrains.kotlinconf.navigation.ScheduleScreen
 import org.jetbrains.kotlinconf.navigation.navigateByLocalNotificationId
 
 @ActivityKey(MainActivity::class)
@@ -38,6 +39,7 @@ class MainActivity(
         setContent {
             App(
                 appGraph = appGraph,
+                topLevelRoute = ScheduleScreen,
                 onThemeChange = { isDarkMode ->
                     val systemBarStyle = SystemBarStyle.auto(
                         lightScrim = Color.TRANSPARENT,


### PR DESCRIPTION
Use `ScheduleScreen` as the default top-level route in MainActivity.