### PR TITLE
Cancel start notification when posting session end notification

### DIFF
--- a/app/shared/src/androidMain/kotlin/org/jetbrains/kotlinconf/AndroidLocalNotificationService.kt
+++ b/app/shared/src/androidMain/kotlin/org/jetbrains/kotlinconf/AndroidLocalNotificationService.kt
@@ -143,6 +143,8 @@ class AndroidLocalNotificationService(
             return
         }
 
+        cancelStartNotificationIfShowingSessionEnd(localNotificationId)
+
         val mainActivityIntent = Intent(context, Class.forName("org.jetbrains.kotlinconf.android.MainActivity"))
             .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
             .putExtra(EXTRA_LOCAL_NOTIFICATION_ID, localNotificationId.toString())
@@ -164,6 +166,17 @@ class AndroidLocalNotificationService(
 
         logger.log(LOG_TAG) { "Showing notification: $localNotificationId, $notification" }
         notificationManager.notify(localNotificationId.hashCode(), notification)
+    }
+
+    private fun cancelStartNotificationIfShowingSessionEnd(localNotificationId: LocalNotificationId) {
+        if (localNotificationId.type != LocalNotificationId.Type.SessionEnd) return
+
+        val startNotificationId = LocalNotificationId(
+            type = LocalNotificationId.Type.SessionStart,
+            id = localNotificationId.id,
+        )
+        notificationManager.cancel(startNotificationId.hashCode())
+        logger.log(LOG_TAG) { "Canceled start notification $startNotificationId before showing end notification $localNotificationId" }
     }
 
     override fun cancel(localNotificationId: LocalNotificationId) {

--- a/app/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/IOSLocalNotificationService.kt
+++ b/app/shared/src/iosMain/kotlin/org/jetbrains/kotlinconf/IOSLocalNotificationService.kt
@@ -47,6 +47,10 @@ class IOSLocalNotificationService(
     ) {
         logger.log(LOG_TAG) { "Posting: $time, $localNotificationId, $title, $message" }
 
+        if (time == null) {
+            cancelStartNotificationIfPostingSessionEnd(localNotificationId)
+        }
+
         val content = UNMutableNotificationContent().apply {
             setTitle(title)
             setBody(message)
@@ -81,6 +85,18 @@ class IOSLocalNotificationService(
                 }
             }
         }
+    }
+
+    private fun cancelStartNotificationIfPostingSessionEnd(localNotificationId: LocalNotificationId) {
+        if (localNotificationId.type != LocalNotificationId.Type.SessionEnd) return
+
+        val startNotificationId = LocalNotificationId(
+            type = LocalNotificationId.Type.SessionStart,
+            id = localNotificationId.id,
+        )
+        val identifiers = listOf(startNotificationId.toString())
+        notificationCenter.removeDeliveredNotificationsWithIdentifiers(identifiers)
+        logger.log(LOG_TAG) { "Canceled delivered start notification $startNotificationId before posting end notification $localNotificationId" }
     }
 
     override fun cancel(localNotificationId: LocalNotificationId) {


### PR DESCRIPTION
## Motivation
A bit overwhelmed by notifications since I bookmark many interesting sessions and later just choose one. I felt it was natural/essential to cancel the start notification if the end notification is posted.

## Note
* Used AI to write this code
* Tested on Android only