### PR TITLE
Provide platform-specific Coil PlatformContext on web targets

### DIFF
--- a/app/ui-components/src/jsMain/kotlin/org/jetbrains/kotlinconf/ui/PlatformContext.js.kt
+++ b/app/ui-components/src/jsMain/kotlin/org/jetbrains/kotlinconf/ui/PlatformContext.js.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.kotlinconf.ui
+
+import coil3.PlatformContext
+
+internal actual val platformContext: PlatformContext = PlatformContext.INSTANCE

--- a/app/ui-components/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/ui/PlatformContext.wasmJs.kt
+++ b/app/ui-components/src/wasmJsMain/kotlin/org/jetbrains/kotlinconf/ui/PlatformContext.wasmJs.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.kotlinconf.ui
+
+import coil3.PlatformContext
+
+internal actual val platformContext: PlatformContext = PlatformContext.INSTANCE

--- a/app/ui-components/src/webMain/kotlin/org/jetbrains/kotlinconf/ui/InitCoil.kt
+++ b/app/ui-components/src/webMain/kotlin/org/jetbrains/kotlinconf/ui/InitCoil.kt
@@ -7,9 +7,11 @@ import coil3.intercept.Interceptor
 import coil3.request.ImageResult
 import coil3.util.DebugLogger
 
+internal expect val platformContext: PlatformContext
+
 fun initCoil() {
     SingletonImageLoader.setSafe {
-        ImageLoader.Builder(PlatformContext.INSTANCE)
+        ImageLoader.Builder(platformContext)
             .components {
                 add(SessionizeImageInterceptor())
             }


### PR DESCRIPTION
## Summary
- Introduce `internal expect val platformContext: PlatformContext` in `webMain` and use it when building the Coil `ImageLoader`, replacing the previous `PlatformContext.INSTANCE`
- Add `actual` implementations under the new `jsMain` and `wasmJsMain` source sets in `:app:ui-components`

This is the commit previously landed directly on `main` as `b55e380f Fix web build`, now routed through review.

## Test plan
- [ ] `./gradlew :app:webApp:wasmJsBrowserDevelopmentRun` — images load in the wasmJs build
- [ ] JS browser target compiles and images render

🤖 Generated with [Claude Code](https://claude.com/claude-code)