### PR TITLE
Pin Node to 22.22.0 for JS and Wasm toolchains

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,8 @@
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsEnvSpec
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsEnvSpec
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsPlugin
+
 plugins {
     alias(libs.plugins.aboutLibraries) apply false
     alias(libs.plugins.androidApplication) apply false
@@ -12,6 +17,18 @@ plugins {
     alias(libs.plugins.jib) apply false
     alias(libs.plugins.googleServices) apply false
     alias(libs.plugins.metro) apply false
+}
+
+// Pin Node.js to the last 22.x LTS. Node 24/25 prebuilt linux-x64 binaries
+// require GLIBC newer than what some CI images provide (see GLIBC_2.27 errors).
+val pinnedNodeVersion = "22.22.0"
+allprojects {
+    plugins.withType<NodeJsPlugin> {
+        extensions.configure<NodeJsEnvSpec> { version.set(pinnedNodeVersion) }
+    }
+    plugins.withType<WasmNodeJsPlugin> {
+        extensions.configure<WasmNodeJsEnvSpec> { version.set(pinnedNodeVersion) }
+    }
 }
 
 apply(from = "gradle/releases.gradle.kts")


### PR DESCRIPTION
## Summary
- Kotlin 2.3.21 defaults Node to 24.10.0 (JS) and 25.0.0 (Wasm); both prebuilt linux-x64 binaries require GLIBC newer than some CI agents provide (we saw `GLIBC_2.27 not found` on the failing image).
- Pin both `NodeJsEnvSpec` and `WasmNodeJsEnvSpec` to 22.22.0 — the last 22.x LTS already used by this repo. Node 22's prebuilds need GLIBC >= 2.28, which Ubuntu 22.04 (GLIBC 2.35) and newer easily satisfy.

## Test plan
- [x] `./gradlew :app:webApp:kotlinNodeJsSetup :app:webApp:kotlinWasmNodeJsSetup --info --rerun-tasks` — both resolve `node-22.22.0`.
- [x] `./gradlew :app:webApp:composeCompatibilityBrowserDistribution` — BUILD SUCCESSFUL.
- [ ] CI green on the previously-failing remote agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)