### PR TITLE
Use absolute path for the admin SPA bundle

### DIFF
--- a/app/adminApp/src/jsMain/resources/index.html
+++ b/app/adminApp/src/jsMain/resources/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!-- ABOUTME: Shell page for the Compose HTML admin SPA. -->
-<!-- ABOUTME: Mounts the app on #root and loads the admin.js bundle (relative so it works under /admin/). -->
+<!-- ABOUTME: Mounts the app on #root and loads the admin.js bundle from the /admin/ mount point. -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -103,6 +103,6 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="admin.js"></script>
+<script src="/admin/admin.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Admin panel renders blank because the script bundle 404s.

- `index.html` used a relative `<script src=\"admin.js\">`. When the page is loaded as `/admin` (no trailing slash), the browser resolves it against `/`, requesting `/admin.js` (404) instead of `/admin/admin.js` (200, 1.3 MB).
- Switched to an absolute `/admin/admin.js` so the bundle loads regardless of trailing-slash on the URL.

## Test plan
- [x] `curl -sI https://kotlinconf-app-prod.labs.jb.gg/admin.js` → 404 (current bug).
- [x] `curl -sI https://kotlinconf-app-prod.labs.jb.gg/admin/admin.js` → 200, 1.3 MB.
- [ ] After deploy: open `/admin` (no trailing slash) and confirm the SPA renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)