### PR TITLE
Remove yearless client-data backend routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,6 @@ The `app:shared` module defines custom intermediate source sets beyond the defau
 **Route structure** (`RoutesModule.kt`):
 - Year-agnostic: `/healthz`, `/time`, `/admin/*`, `/config`
 - Year-prefixed: `/{year}/conference`, `/{year}/conference-info`, `/{year}/schedule`, `/{year}/vote`, `/{year}/sign`, `/{year}/golden-kodee`, `/{year}/documents/*`, etc.
-- Year-less routes also registered for backwards compatibility (default year: 2025).
 
 **Data flow**: `SessionizeService` polls the Sessionize API on a configurable interval and caches schedule data in-memory. `KotlinConfRepository` handles all DB operations (users, votes, feedback, signed policies) using `suspendTransaction`.
 

--- a/backend/src/main/kotlin/org/jetbrains/kotlinconf/backend/RoutesModule.kt
+++ b/backend/src/main/kotlin/org/jetbrains/kotlinconf/backend/RoutesModule.kt
@@ -27,9 +27,6 @@ fun Application.routesModule() {
         adminPanelRoutes()
         configRoutes()
 
-        // Routes without the year prefix for backwards compatibility
-        yearBasedRoutes()
-
         // Routes with year prefix: /{year}/...
         route("/{year}") {
             yearBasedRoutes()
@@ -38,10 +35,8 @@ fun Application.routesModule() {
 }
 
 /**
- * Registers all year-based routes.
- * Route handlers will check for the "year" path parameter:
- * - If present: validate and use that year
- * - If absent: use 2025 (temporary, will be removed soon)
+ * Registers all year-based routes under the "/{year}" path prefix.
+ * Route handlers read the "year" path parameter, then validate and use that year.
  */
 private fun Route.yearBasedRoutes() {
     userRoutes()

--- a/backend/src/main/kotlin/org/jetbrains/kotlinconf/backend/routes/utils.kt
+++ b/backend/src/main/kotlin/org/jetbrains/kotlinconf/backend/routes/utils.kt
@@ -23,17 +23,14 @@ internal suspend fun ApplicationCall.validatePrincipal(database: KotlinConfRepos
     return principal
 }
 
-private const val DEFAULT_YEAR = 2025
-
 val ARCHIVED_YEAR_FORBIDDEN = HttpStatusCode(403, "Forbidden: Archived Year")
 
 /**
- * Gets the year for this request.
- * - If "year" path parameter is absent: returns [DEFAULT_YEAR] (the archive year for backwards-compatible routes)
- * - If "year" path parameter exists: validates and returns it (throws NotFound if invalid)
+ * Gets the year for this request from the "year" path parameter, then validates and returns it
+ * (throws NotFound if the parameter is missing or invalid).
  */
 internal fun RoutingContext.getYearFromPath(config: ConferenceConfig): Int {
-    val yearParam = call.parameters["year"] ?: return DEFAULT_YEAR
+    val yearParam = call.parameters["year"] ?: throw NotFound()
 
     val year = yearParam.toIntOrNull() ?: throw NotFound()
 

--- a/backend/src/test/kotlin/ApiTest.kt
+++ b/backend/src/test/kotlin/ApiTest.kt
@@ -27,13 +27,13 @@ class ApiTest {
     @Test
     fun testConferenceCallRepeatable() = runTest {
         repeat(10) {
-            client.get("/conference").body<Conference>()
+            client.get("/2025/conference").body<Conference>()
         }
     }
 
     @Test
     fun testWorkshopPartsAreMerged() = runTest {
-        val conference = client.get("/conference").body<Conference>()
+        val conference = client.get("/2025/conference").body<Conference>()
         val workshops = conference.sessions.filter { it.tags?.contains("Workshop") == true }
 
         for (workshop in workshops) {

--- a/backend/src/test/kotlin/DocumentsApiTest.kt
+++ b/backend/src/test/kotlin/DocumentsApiTest.kt
@@ -34,16 +34,6 @@ class DocumentsApiTest {
     }
 
     @Test
-    fun `single document endpoint without year returns document for current year`() = runTest {
-        val response = client.get("/documents/code-of-conduct.md")
-        assertEquals(HttpStatusCode.OK, response.status)
-
-        val content = response.bodyAsText()
-        assertTrue(content.contains("Code of Conduct"))
-        assertTrue(content.contains("2025"))
-    }
-
-    @Test
     fun `single document endpoint with archived year returns archived document`() = runTest {
         val response = client.get("/2024/documents/code-of-conduct.md")
         assertEquals(HttpStatusCode.OK, response.status)

--- a/backend/src/test/kotlin/MapsApiTest.kt
+++ b/backend/src/test/kotlin/MapsApiTest.kt
@@ -100,10 +100,12 @@ class MapsApiTest {
         val mapData = info.mapData
 
         for (floor in mapData.floors) {
-            val lightResponse = client.get(floor.svgPathLight)
+            // Map SVG paths in conference-info are relative (the client prepends the year prefix),
+            // so fetch them under the /{year} prefix.
+            val lightResponse = client.get("/2025/${floor.svgPathLight}")
             assertEquals(HttpStatusCode.OK, lightResponse.status, "Failed to fetch ${floor.svgPathLight}")
 
-            val darkResponse = client.get(floor.svgPathDark)
+            val darkResponse = client.get("/2025/${floor.svgPathDark}")
             assertEquals(HttpStatusCode.OK, darkResponse.status, "Failed to fetch ${floor.svgPathDark}")
         }
     }

--- a/backend/src/test/kotlin/YearBasedApiTest.kt
+++ b/backend/src/test/kotlin/YearBasedApiTest.kt
@@ -38,15 +38,6 @@ class YearBasedApiTest {
     }
 
     @Test
-    fun `conference endpoint without year returns current year data`() = runTest {
-        val response = client.get("/conference")
-        assertEquals(HttpStatusCode.OK, response.status)
-
-        // Verify that we have some sessions
-        assertNotEquals(0, response.body<Conference>().sessions.size)
-    }
-
-    @Test
     fun `conference endpoint with current year returns data`() = runTest {
         val response = client.get("/2025/conference")
         assertEquals(HttpStatusCode.OK, response.status)
@@ -81,7 +72,7 @@ class YearBasedApiTest {
     fun `vote POST on archived year returns 403`() = runTest {
         // First sign up a user
         val userId = "test-user-${System.currentTimeMillis()}"
-        client.post("/sign") {
+        client.post("/2025/sign") {
             setBody(userId)
             contentType(ContentType.Text.Plain)
         }
@@ -99,7 +90,7 @@ class YearBasedApiTest {
     fun `feedback POST on archived year returns 403`() = runTest {
         // First sign up a user
         val userId = "test-user-feedback-${System.currentTimeMillis()}"
-        client.post("/sign") {
+        client.post("/2025/sign") {
             setBody(userId)
             contentType(ContentType.Text.Plain)
         }

--- a/docs/ARCHIVE.md
+++ b/docs/ARCHIVE.md
@@ -40,4 +40,3 @@ conference:
 
 - http://0.0.0.0:8080/{YEAR}/conference should return the archived data
 - http://0.0.0.0:8080/{NEW_YEAR}/conference should return the live Sessionize data
-- http://0.0.0.0:8080/conference should still return 2025 data


### PR DESCRIPTION
## Summary

Removes the backwards-compatible prefix-less (no-year) backend routes for client data. All client-data routes now live **only** under the `/{year}` prefix.

## Changes

- **`RoutesModule.kt`**: Dropped the prefix-less `yearBasedRoutes()` registration. `userRoutes`, `scheduleRoutes`, `votingRoutes`, `imageProxyRoutes`, `conferenceInfoRoutes`, `goldenKodeeRoutes`, and `documentsRoutes` are now served exclusively under `/{year}`.
- **`routes/utils.kt`**: Removed the now-dead `DEFAULT_YEAR = 2025` fallback in `getYearFromPath`. A missing/invalid year now returns 404. Doc comments updated accordingly.
- **Tests**: Updated `ApiTest`, `YearBasedApiTest`, and `DocumentsApiTest` to use year-prefixed URLs; removed the tests that specifically asserted the removed prefix-less behavior; fixed `MapsApiTest` to fetch relative map-SVG paths under the `/{year}` prefix.
- **Docs**: Removed mentions of the year-less backwards-compatible routes in `CLAUDE.md` and `docs/ARCHIVE.md`.

## Verification

- `./gradlew :backend:test` passes (49 tests).
- Clients are unaffected: `YearlyApi` and `AdminApi` already build year-prefixed URLs, and relative map-SVG paths are prepended with the year by `YearlyApi`.