### PR TITLE
Pin desktop target to toolchain 21

### DIFF
--- a/app/desktopApp/build.gradle.kts
+++ b/app/desktopApp/build.gradle.kts
@@ -12,6 +12,8 @@ kotlin {
         implementation(libs.compose.components.resources)
         implementation(libs.kotlinx.coroutines.swing)
     }
+
+    jvmToolchain(21)
 }
 
 compose.desktop {


### PR DESCRIPTION
Add jvmToolchain(21), since otherwise on my machine, I get this wonderful error message:

```
Error: LinkageError occurred while loading main class org.jetbrains.kotlinconf.MainKt
    java.lang.UnsupportedClassVersionError: org/jetbrains/kotlinconf/MainKt has been compiled by a more recent version of the Java Runtime (class file version 69.0), this version of the Java Runtime only recognizes class file versions up to 65.0
```